### PR TITLE
Evol : Initialisation du DataController pour la Fiche Article

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/FicheArticleDataController.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/FicheArticleDataController.java
@@ -1,0 +1,35 @@
+package fr.cg44.plugin.socle.datacontroller;
+
+import com.jalios.jcms.BasicDataController;
+import com.jalios.jcms.ControllerStatus;
+import com.jalios.jcms.Data;
+import com.jalios.jcms.plugin.PluginComponent;
+import com.jalios.util.Util;
+
+import generated.FicheArticle;
+
+public class FicheArticleDataController extends BasicDataController implements PluginComponent {
+	
+	public ControllerStatus checkIntegrity(Data data) {
+		FicheArticle itFiche = (FicheArticle) data;
+				
+		if ( (Util.notEmpty(itFiche.getImagePrincipale()) || itFiche.getTypeSimple()) && Util.isEmpty(itFiche.getContenuParagraphe())) {
+			// Type est simple, pas de contenu -> on retourne une erreur
+			ControllerStatus status = new ControllerStatus();
+			status.setProp("msg.edit.empty-field", "Contenu paragraphe");
+			return status;
+		} else if (! itFiche.getTypeSimple() 
+				&& Util.isEmpty(itFiche.getContenuParagraphe_1()) 
+				&& Util.isEmpty(itFiche.getContenuParagraphe_2())
+				&& Util.isEmpty(itFiche.getContenuParagraphe_3())
+				&& Util.isEmpty(itFiche.getContenuParagraphe_4())) {
+			// Type est onglet, pas de contenu -> on retourne une erreur
+			ControllerStatus status = new ControllerStatus();
+			status.setProp("msg.edit.empty-field", "Contenu paragraphe des onglets");
+			return status;
+		}
+		
+		return super.checkIntegrity(data);
+	}
+	
+}

--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -166,6 +166,7 @@
 
   <plugincomponents>
     <channellistener class="fr.cg44.plugin.socle.channellistener.SocleChannelListener" />
+    <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FicheArticleDataController" types="FicheArticle" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.SoclePortalPolicyFilter" />
   </plugincomponents>
     


### PR DESCRIPTION
Le comportement actuel est de forcer la complétion du champ "Contenu paragraphe" sur un type simple, et d'au moins un des champs "Contenu paragraphe de l'onglet" sur un type onglet.