### PR TITLE
Fix wysiwyg FicheArticle et FicheActu

### DIFF
--- a/plugins/SoclePlugin/types/FicheActu/doFicheActuFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheActu/doFicheActuFullDisplay.jsp
@@ -37,7 +37,7 @@
 				       <jalios:if predicate="<%= Util.notEmpty(itTitle) %>">
 				           <h2 id="titreParagraphe<%= itCounter %>"><%= itTitle %></h2>
 				       </jalios:if>
-				       <%= obj.getContenuParagraphe()[itCounter-1] %>
+				       <jalios:wysiwyg><%= obj.getContenuParagraphe()[itCounter-1] %></jalios:wysiwyg>
 			       </div>
 		       </div>
 	       </section>

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleOnglets.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleOnglets.jspf
@@ -101,7 +101,7 @@
                                 : false %>">
                                 <h2 class="h2-like" id="titreParagraphe<%=itCounter%>"><%=currentTitresParagraphes[itCounter - 1]%></h2>
                             </jalios:if>
-                            <%=itContenu%>
+                            <jalios:wysiwyg><%=itContenu%></jalios:wysiwyg>
                         </section>
                     </jalios:foreach>
                     

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
@@ -27,7 +27,7 @@
 						: false %>">
 					<h2 class="h2-like" id="titreParagraphe<%=itCounter%>"><%=obj.getTitreParagraphe()[itCounter - 1]%></h2>
 				</jalios:if>
-				<%=itParagraphe%>
+				<jalios:wysiwyg><%=itParagraphe%></jalios:wysiwyg>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Ajout de la balise <jalios:wysiwyg> autour des champs wysiwyg sinon les liens internes (<jalios:datalink>) ne sont pas interprétés.