### PR TITLE
Intégration des vidéo dans les fiches article

### DIFF
--- a/WEB-INF/data/types/ListeDeContenus/ListeDeContenus.xml
+++ b/WEB-INF/data/types/ListeDeContenus/ListeDeContenus.xml
@@ -13,7 +13,7 @@
       <label xml:lang="fr">Contenus</label>
       <description xml:lang="fr">Choisir des contenus de même type (ex : que des documents ou que des fiches lieu)</description>
     </field>
-    <field name="styleDeFond" editor="enumerate" required="true" compactDisplay="false" type="String" chooser="checkbox" valueList="none|ds44-borderContainer|ds44-bgGray|ds44-theme" ml="false" descriptionType="tooltip" labelList="Aucun|Encadré|Gris|Vert" searchable="false" html="false" checkHtml="true">
+    <field name="styleDeFond" editor="enumerate" required="true" compactDisplay="false" type="String" chooser="checkbox" valueList="none|ds44-bgGray|ds44-theme" ml="false" descriptionType="tooltip" labelList="Aucun|Gris|Vert" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Style de fond</label>
     </field>
   </fields>

--- a/WEB-INF/data/types/Video/Video.xml
+++ b/WEB-INF/data/types/Video/Video.xml
@@ -31,7 +31,7 @@
     <field name="imageCopyright" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="true" html="false" checkHtml="true" tab="common">
       <label xml:lang="fr">Copyright image</label>
     </field>
-    <field name="transcriptFile" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.FileDocument" ml="false" parent="false" tab="common">
+    <field name="fichierTranscript" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.FileDocument" ml="false" parent="false" tab="common">
       <label xml:lang="fr">Fichier de transcript</label>
     </field>
     <field name="description" editor="wysiwyg" required="false" compactDisplay="false" tab="common" type="String" searchable="false" rows="16" cols="100" ml="false" checkHtml="true" inline="true" descriptionType="tooltip" html="false">

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -200,6 +200,8 @@ jcmsplugin.socle.facette.category-liees.label: Catégories liées
 jcmsplugin.socle.facette.maj-sous-theme.label: mise à jour automatique des sous-thèmes
 jcmsplugin.socle.facette.tri-alphabetique.label: triés par ordre alphabétique
 
+jcmsplugin.socle.video.telecharger-transcript: Télécharger le fichier de transcription
+
 # ------------------------------------------------------------
 #  Fil ariane
 # ------------------------------------------------------------

--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -35,6 +35,13 @@
     type="String"
     description="Le chemin du fichier image mobile"
 %>
+<%@ attribute name="fichierTranscript"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le chemin du fichier de transcription"
+%>
 <%@ attribute name="alt"
     required="false"
     fragment="false"
@@ -113,6 +120,9 @@ boolean hasFigcaption = Util.notEmpty(legend) || Util.notEmpty(copyright);
 	            <div class="ds44-grid12-offset-1">
 	                <iframe width="100%" height="480" src="<%=urlVideo%>" frameborder="0" allowfullscreen></iframe>
 	                <%-- TODO : affichage du fichier de transcript de la vidéo --%>
+	                <jalios:if predicate="<%=Util.notEmpty(fichierTranscript)%>">
+	                   <a href="<%=fichierTranscript%>"><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript") %></a>
+	                </jalios:if>
 	            </div>
 	        </div>
 	    </div>

--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -121,7 +121,7 @@ boolean hasFigcaption = Util.notEmpty(legend) || Util.notEmpty(copyright);
 	                <iframe width="100%" height="480" src="<%=urlVideo%>" frameborder="0" allowfullscreen></iframe>
 	                <%-- TODO : affichage du fichier de transcript de la vidéo --%>
 	                <jalios:if predicate="<%=Util.notEmpty(fichierTranscript)%>">
-	                   <a href="<%=fichierTranscript%>"><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript") %></a>
+                        <a href="<%=fichierTranscript%>" target="_blank" title="<%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript") %> <%= JcmsUtil.glp(userLang, "jcmsplugin.socle.accessibily.newTabLabel") %>"><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript") %></a>
 	                </jalios:if>
 	            </div>
 	        </div>

--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -33,7 +33,7 @@
     fragment="false"
     rtexprvalue="true"
     type="String"
-    description="Le chemin du fichier image mobile"
+    description="L'URL de la vidéo"
 %>
 <%@ attribute name="fichierTranscript"
     required="false"
@@ -47,7 +47,7 @@
     fragment="false"
     rtexprvalue="true"
     type="String"
-    description="L'URL de la vidéo"
+    description="Texte alternatif de l'image"
 %>
 <%@ attribute name="legend"
     required="false"

--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -28,12 +28,19 @@
     type="String"
     description="Le chemin du fichier image mobile"
 %>
+<%@ attribute name="urlVideo"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le chemin du fichier image mobile"
+%>
 <%@ attribute name="alt"
     required="false"
     fragment="false"
     rtexprvalue="true"
     type="String"
-    description="Texte alternatif de l'image"
+    description="L'URL de la vidéo"
 %>
 <%@ attribute name="legend"
     required="false"
@@ -99,31 +106,43 @@ boolean hasFigcaption = Util.notEmpty(legend) || Util.notEmpty(copyright);
 	    </div>
     </div>
 </div>
-<jalios:if predicate="<%=Util.notEmpty(imagePath)%>">
-<% if (Util.isEmpty(mobileImagePath)) { mobileImagePath = ThumbnailTag.buildThumbnail(imagePath, 480, 480, imagePath); } %>
-    <div class="ds44-img50">
-        <div class="ds44-inner-container">
-            <div class="ds44-grid12-offset-1">
-                <jalios:if predicate="<%= hasFigcaption%>">
-                    <figure role="figure">
-                </jalios:if>
-	            <picture class="ds44-legendeContainer ds44-container-imgRatio" role="figure" aria-label='<%= legend %> <%= JcmsUtil.glp(userLang, "jcmsplugin.socle.symbol.copyright") %> <%= copyright %>'>
-			        <source media="(max-width: 36em)" srcset="<%=mobileImagePath%>">
-			        <source media="(min-width: 36em)" srcset="<%=imagePath%>">
-			        <img src="<%=imagePath%>" alt='<%= Util.isEmpty(alt) ? JcmsUtil.glp(userLang, "jcmsplugin.socle.illustration") : alt %>' class="ds44-w100 ds44-imgRatio" id="<%=uid%>"/>
-                </picture>
-                <jalios:if predicate="<%= hasFigcaption%>">
-                    <figcaption class="ds44-imgCaption">
-                        <jalios:if predicate="<%= Util.notEmpty(legend)%>">
-                            <%=legend%>
-                        </jalios:if>
-                        <jalios:if predicate="<%= Util.notEmpty(copyright)%>">
-                            © <%=copyright%>
-                        </jalios:if>
-                    </figcaption>
-                  </figure>
-                </jalios:if>
-			</div>
-        </div>
-    </div>
-</jalios:if>
+<jalios:select>
+	<jalios:if predicate="<%=Util.notEmpty(urlVideo)%>">
+	    <div class="ds44-img50">
+	        <div class="ds44-inner-container">
+	            <div class="ds44-grid12-offset-1">
+	                <iframe width="100%" height="480" src="<%=urlVideo%>" frameborder="0" allowfullscreen></iframe>
+	                <%-- TODO : affichage du fichier de transcript de la vidéo --%>
+	            </div>
+	        </div>
+	    </div>
+	</jalios:if>
+	<jalios:if predicate="<%=Util.notEmpty(imagePath)%>">
+	<% if (Util.isEmpty(mobileImagePath)) { mobileImagePath = ThumbnailTag.buildThumbnail(imagePath, 480, 480, imagePath); } %>
+	    <div class="ds44-img50">
+	        <div class="ds44-inner-container">
+	            <div class="ds44-grid12-offset-1">
+	                <jalios:if predicate="<%= hasFigcaption%>">
+	                    <figure role="figure">
+	                </jalios:if>
+		            <picture class="ds44-legendeContainer ds44-container-imgRatio" role="figure" aria-label='<%= legend %> <%= JcmsUtil.glp(userLang, "jcmsplugin.socle.symbol.copyright") %> <%= copyright %>'>
+				        <source media="(max-width: 36em)" srcset="<%=mobileImagePath%>">
+				        <source media="(min-width: 36em)" srcset="<%=imagePath%>">
+				        <img src="<%=imagePath%>" alt='<%= Util.isEmpty(alt) ? JcmsUtil.glp(userLang, "jcmsplugin.socle.illustration") : alt %>' class="ds44-w100 ds44-imgRatio" id="<%=uid%>"/>
+	                </picture>
+	                <jalios:if predicate="<%= hasFigcaption%>">
+	                    <figcaption class="ds44-imgCaption">
+	                        <jalios:if predicate="<%= Util.notEmpty(legend)%>">
+	                            <%=legend%>
+	                        </jalios:if>
+	                        <jalios:if predicate="<%= Util.notEmpty(copyright)%>">
+	                            © <%=copyright%>
+	                        </jalios:if>
+	                    </figcaption>
+	                  </figure>
+	                </jalios:if>
+				</div>
+	        </div>
+	    </div>
+	</jalios:if>
+</jalios:select>

--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
@@ -19,8 +19,8 @@
 	          </jalios:if>
 	          <div class="ds44--m-padding">
 	            <p role="heading" aria-level="3"><a href="<%= itVideo.getDisplayUrl(userLocale) %>"><%= itVideo.getTitle() %></a></p>
-	            <jalios:if predicate="<%= Util.notEmpty(itVideo.getSummary()) %>">
-	               <p><%= itVideo.getSummary() %></p>
+	            <jalios:if predicate="<%= Util.notEmpty(itVideo.getChapo()) %>">
+	               <p><%= itVideo.getChapo() %></p>
 	            </jalios:if>
 	          </div>
 	        </div>

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
@@ -1,4 +1,5 @@
 <%@page import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@ page import="fr.cg44.plugin.socle.VideoUtils" %>
 <%@ page contentType="text/html; charset=UTF-8" %><%
 %><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
 %><%@ include file='/jcore/doInitPage.jspf' %><%

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
@@ -1,6 +1,12 @@
+<%
+String urlVideo = "";
+if(Util.notEmpty(obj.getVideoPrincipale())){
+  urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getVideoPrincipale().getUrlVideo()));
+}
+%>
 
 <ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= obj.getImageMobile() %>" 
-    title="<%= obj.getTitle() %>" legend="<%= obj.getLegende() %>" 
+    urlVideo="<%= urlVideo %>" title="<%= obj.getTitle() %>" legend="<%= obj.getLegende() %>" 
     copyright="<%= obj.getCopyright() %>" 
     userLang="<%= userLang %>" breadcrumb="true"></ds:titleSimple>
 

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
@@ -1,12 +1,17 @@
 <%
+// Récupération des infos de vidéo, dans la cas d'une fiche article
 String urlVideo = "";
+String fichierTranscriptVideo = "";
 if(Util.notEmpty(obj.getVideoPrincipale())){
   urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getVideoPrincipale().getUrlVideo()));
+  if(Util.notEmpty(obj.getVideoPrincipale().getFichierTranscript())){
+    fichierTranscriptVideo = obj.getVideoPrincipale().getFichierTranscript().getDownloadUrl();
+  }
 }
 %>
 
 <ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= obj.getImageMobile() %>" 
-    urlVideo="<%= urlVideo %>" title="<%= obj.getTitle() %>" legend="<%= obj.getLegende() %>" 
+    urlVideo="<%= urlVideo %>" fichierTranscript="<%=fichierTranscriptVideo %>" title="<%= obj.getTitle() %>" legend="<%= obj.getLegende() %>" 
     copyright="<%= obj.getCopyright() %>" 
     userLang="<%= userLang %>" breadcrumb="true"></ds:titleSimple>
 

--- a/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusDocuments.jsp
+++ b/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusDocuments.jsp
@@ -10,7 +10,7 @@ if (Util.notEmpty(obj.getStyleDeFond()) && !obj.getStyleDeFond().equals("none"))
 %>
 
 <jalios:if predicate="<%=Util.notEmpty(obj.getContenus())%>">
-	<section class="ds44-box mts <%=styleFond%>">
+	<section class="ds44-box mtm <%=styleFond%>">
 	  <div class="ds44-innerBoxContainer">
 	    <jalios:if predicate="<%=Util.notEmpty(obj.getLibelleTitre(userLang)) %>">
 	        <p role="heading" aria-level="2" class="ds44-box-heading"><%=obj.getLibelleTitre(userLang) %></p>

--- a/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
+++ b/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
@@ -13,9 +13,15 @@
 <%
 String uniqueIDiframe = UUID.randomUUID().toString();
 String urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getUrlVideo()));
+String fichierTranscript = Util.notEmpty(obj.getFichierTranscript()) ? obj.getFichierTranscript().getDownloadUrl() : "";
 
 %>
-<iframe id="<%=uniqueIDiframe%>" width="100%" height="480" src="<%=urlVideo%>" frameborder="0" allowfullscreen></iframe>
+<div class="ds44-negativeOffset-2 ds44-mtb3">
+    <iframe id="<%=uniqueIDiframe%>" width="100%" height="480" src="<%=urlVideo%>" frameborder="0" allowfullscreen></iframe>
+    <jalios:if predicate="<%=Util.notEmpty(fichierTranscript)%>">
+        <a href="<%=fichierTranscript%>" target="blank" title="<%= glp("jcmsplugin.socle.video.telecharger-transcript") %> <%= glp("jcmsplugin.socle.accessibily.newTabLabel") %>"><%= glp("jcmsplugin.socle.video.telecharger-transcript") %></a>
+    </jalios:if>
+</div>
 
 <jalios:if predicate="<%=Util.notEmpty(obj.getChapitre()) && Util.notEmpty(obj.getTimecode()) && Util.notEmpty(obj.getLibelleTimecode()) %>">
     <%


### PR DESCRIPTION
Si une vidéo est présente, alors elle doit remplacer l'image, dans la zone de titre.