### PR TITLE
Fix RS-780 bloc "grands projets"

### DIFF
--- a/WEB-INF/data/types/Lien/Lien.xml
+++ b/WEB-INF/data/types/Lien/Lien.xml
@@ -6,8 +6,8 @@
     <label xml:lang="fr">Titre</label>
   </title>
   <fields>
-    <field name="lienSurContenu" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.Publication" parent="false" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true" tab="contenu">
-      <label xml:lang="fr">Lien sur contenu</label>
+    <field name="lienInterne" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.Publication" parent="false" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true" tab="contenu">
+      <label xml:lang="fr">Lien interne</label>
       <description xml:lang="fr">&lt;div class="wysiwyg"&gt;&lt;p&gt;Sera prioritaire sur l'autre lien&lt;/p&gt;&lt;/div&gt;</description>
     </field>
     <field name="lienExterne" editor="url" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" openWindow="false" tab="contenu">

--- a/WEB-INF/data/types/PortletMiseEnAvantDeContenus/PortletMiseEnAvantDeContenus.xml
+++ b/WEB-INF/data/types/PortletMiseEnAvantDeContenus/PortletMiseEnAvantDeContenus.xml
@@ -18,9 +18,13 @@
     <field name="titreCompletDeLien" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="true">
       <label xml:lang="fr">Titre complet de lien</label>
     </field>
-    <field name="lien" editor="url" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" openWindow="false">
-      <label xml:lang="fr">Lien</label>
+    <field name="lienInterne" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.Publication" parent="false" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true" tab="contenu">
+      <label xml:lang="fr">Lien interne</label>
+      <description xml:lang="fr">&lt;div class="wysiwyg"&gt;&lt;p&gt;Sera prioritaire sur l'autre lien&lt;/p&gt;&lt;/div&gt;</description>
     </field>
+    <field name="lienExterne" editor="url" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" openWindow="false" tab="contenu">
+      <label xml:lang="fr">Lien externe</label>
+    </field>     
     <field type="super" />
   </fields>
 </type>

--- a/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
@@ -22,17 +22,17 @@ String titleAttr = "";
 */
 if (isLien) {
   Lien itLien = (Lien) pub;
-  if (Util.notEmpty(itLien.getLienSurContenu())) {
-    if (itLien.getLienSurContenu() instanceof FileDocument) {
+  if (Util.notEmpty(itLien.getLienInterne())) {
+    if (itLien.getLienInterne() instanceof FileDocument) {
 		isDoc = true;
-		FileDocument itDoc = (FileDocument) itLien.getLienSurContenu();
+		FileDocument itDoc = (FileDocument) itLien.getLienInterne();
 		fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
 		fileSize = Util.formatFileSize(itDoc.getSize());
 		fileInfos = " - " + fileSize + " - " + fileType;
 		urlPub = itDoc.getDownloadUrl();
 		targetBlank = true;
       }else{
-        urlPub = itLien.getLienSurContenu().getDisplayUrl(userLocale);
+        urlPub = itLien.getLienInterne().getDisplayUrl(userLocale);
       }
   }else if (Util.notEmpty(itLien.getLienExterne())) {
     urlPub = itLien.getLienExterne();

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
@@ -24,39 +24,63 @@ int nbPub = allContents.size();
 int nbPubCol1 = nbPub/2 + nbPub%2;
 int nbPubCol2 = nbPub-nbPubCol1;
 
+// Gestion du bouton
+boolean isLienExterne = Util.isEmpty(box.getLienInterne());
+String labelBouton = box.getLabelDuLien();
+String urlBouton = "";
+String targetAttr = "";
+String titleAttr = "";
+
+// Accessibilité : on place un attribut "title" sur le lien uniquement si le lien s'ouvre dans une nouvelle fenêtre
+if(isLienExterne){
+  urlBouton = box.getLienExterne();
+  targetAttr = "target=\"_blank\" ";
+  titleAttr = "title=\"" +  labelBouton + glp("jcmsplugin.socle.accessibily.newTabLabel")+"\"";
+}
+else{
+  urlBouton = box.getLienInterne().getDisplayUrl(userLocale);  
+}
+
 %>
 
-<section class="ds44-container-large ds44--xl-padding-tb">
-    <div class="ds44-inner-container">
-        <div class="grid-12-small-1 ds44-flex-valign-center">
-        
-            <%-- Présentation de gauche --%>
-			<div class="col-4 colFocusProjets">
-                <jalios:if predicate='<%=Util.notEmpty(box.getTitreVisuel()) %>'>
-                    <h2 class="h2-like" id="idTitre2"><%= box.getTitreVisuel() %></h2>
-			    </jalios:if>
-			    <jalios:if predicate='<%=Util.notEmpty(box.getSoustitre()) %>'>
-                    <p class="ds44-introduction ds44-hide-tinyToLarge"><%= box.getSoustitre() %></p>
-                </jalios:if>
+<section class="ds44-container-fluid ds44--xxl-padding-tb">
+	<section class="ds44-container-large">
+	    <div class="ds44-inner-container">
+	        <div class="grid-12-small-1 ds44-flex-valign-center">
+	        
+	            <%-- Présentation de gauche --%>
+				<div class="col-4 colFocusProjets">
+	                <jalios:if predicate='<%=Util.notEmpty(box.getTitreVisuel()) %>'>
+	                    <h2 class="h2-like" id="idTitre2"><%= box.getTitreVisuel() %></h2>
+				    </jalios:if>
+				    <jalios:if predicate='<%=Util.notEmpty(box.getSoustitre()) %>'>
+	                    <div class="ds44-introduction ds44-hide-tinyToLarge"><%= box.getSoustitre() %></div>
+	                </jalios:if>
+                    <%-- Bouton desktop --%>
+                    <jalios:if predicate='<%=Util.notEmpty(box.getLabelDuLien()) %>'>
+                        <a href="<%= urlBouton %>" <%= titleAttr %> <%= targetAttr %> class="ds44-btnStd ds44-hide-tinyToLarge ds44-btnFullMobile"><span class="ds44-btnInnerText"><%= box.getLabelDuLien() %></span><i class="icon icon-long-arrow-right" aria-hidden="true"></i></a>
+                    </jalios:if>
+				</div>
+				
+				<%-- Tuiles --%>
+				<div class="col-4 colFocusProjets">
+					<jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" max="<%= nbPubCol1 %>">
+	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+					</jalios:foreach>
+				</div>
+				<%if(nbPub > 1){ %>
+	            <div class="col-4 colFocusProjets">
+	                <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" skip="<%= nbPubCol1 %>">
+	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+	                </jalios:foreach>
+	            </div>
+	            <%} %>
+	            
+	            <%-- Bouton mobile --%>
                 <jalios:if predicate='<%=Util.notEmpty(box.getLabelDuLien()) %>'>
-                    <a href="#" class="ds44-btnStd ds44-hide-tinyToLarge ds44-btnFullMobile"><span class="ds44-btnInnerText"><%= box.getLabelDuLien() %></span><i class="icon icon-long-arrow-right" aria-hidden="true"></i></a>
+                    <a href="<%= urlBouton %>" <%= titleAttr %> <%= targetAttr %> class="ds44-btnStd ds44-show-tiny-to-medium ds44-show-mobile ds44-btnFullMobile"><span class="ds44-btnInnerText"><%= box.getLabelDuLien() %></span><i class="icon icon-long-arrow-right" aria-hidden="true"></i></a>
                 </jalios:if>
-			</div>
-			
-			<%-- Tuiles --%>
-			<div class="col-4 colFocusProjets">
-				<jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" max="<%= nbPubCol1 %>">
-                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
-				</jalios:foreach>
-			</div>
-			<%if(nbPub > 1){ %>
-            <div class="col-4 colFocusProjets">
-                <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" skip="<%= nbPubCol1 %>">
-                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
-                </jalios:foreach>
-            </div>
-            <%} %>
-            
-      </div>
-    </div>
+	      </div>
+	    </div>
+	</section>
 </section>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
@@ -68,13 +68,13 @@ else{
 	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
 					</jalios:foreach>
 				</div>
-				<%if(nbPub > 1){ %>
-	            <div class="col-4 colFocusProjets">
-	                <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" skip="<%= nbPubCol1 %>">
-	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
-	                </jalios:foreach>
-	            </div>
-	            <%} %>
+				<jalios:if predicate='<%=nbPub > 1 %>'>
+		            <div class="col-4 colFocusProjets">
+		                <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" skip="<%= nbPubCol1 %>">
+		                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+		                </jalios:foreach>
+		            </div>
+                </jalios:if>
 	            
 	            <%-- Bouton mobile --%>
                 <jalios:if predicate='<%=Util.notEmpty(box.getLabelDuLien()) %>'>


### PR DESCRIPTION
Rajout de la gestion des liens internes sur le bouton dans la portlet "Mise en avant de contenus" + renommage champ lien externe
Gestion du lien du bouton dans le gabarit
Refacto suite renommage champ.
