### PR TITLE
Wysiwyg balise script

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -70,6 +70,7 @@ wysiwyg.plugins.dsicons: plugins/SoclePlugin/wysiwyg/plugins/dsicons/plugin.js
 
 wysiwyg.sanitize-html.whitelist.default.tags:\
   a[class|style|id|href|title|rel|name|hreflang|target],\
+  script[src|async|defer|type|charset],\
   abbr[class|style|id|title],\
   acronym[class|style|id|title],\
   address,\

--- a/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-charteconfig.conf
+++ b/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-charteconfig.conf
@@ -27,7 +27,11 @@
       boutonContourLarge: {selector: 'a', classes: 'ds44-btnStd ds44-btnStd--large'},
       boutonNoirLarge: {selector: 'a', classes: 'ds44-btn--invert ds44-btnStd ds44-btnStd--large'},
       boutonApplatLarge: {selector: 'a', classes: 'ds44-btnStd ds44-btn--contextual ds44-btnStd--large'}
-    }
- 
+    },
+    
+    ::include{'property': 'wysiwyg.fragment.configuration.mention'},
+
+    ::include{'property': 'wysiwyg.fragment.configuration.extended-elements'}
+    
   }
 }​​

--- a/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-styles.conf
+++ b/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-styles.conf
@@ -9,8 +9,7 @@
     ],
     style_formats_autohide: true,
     
-    extended_valid_elements : 'script[src|async|defer|type|charset]',
-    custom_elements : 'script'
+    extended_valid_elements : 'script[src|async|defer|type|charset]'
     
   }
 }

--- a/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-styles.conf
+++ b/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-styles.conf
@@ -7,6 +7,10 @@
       {title: 'h3-like', selector: 'p,h2,h3,h4,h5,h6', classes: 'h3-like'},
       {title: 'h4-like', selector: 'p,h2,h3,h4,h5,h6', classes: 'h4-like'}
     ],
-    style_formats_autohide: true
+    style_formats_autohide: true,
+    
+    extended_valid_elements : 'script[src|async|defer|type|charset]',
+    custom_elements : 'script'
+    
   }
 }


### PR DESCRIPTION
J'ai ajouté le code dans le fichier : configuration-styles.conf
A voir si faire un autre fichier ou renommer celui-ci qui ne gère plus seulement le style mais aussi les balises autorisées.
Ce code ne peut fonctionner qu'après la correction du bug Jalios : https://community.jalios.com/jcms/jc1_543054/fr/wysiwyg-extended-valid-elements-de-tinymce-ne-marche-pas-sur-jalios