### PR TITLE
Fix titre image/vidéo sur FicheArticle / FicheActu / Video

### DIFF
--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -1,4 +1,5 @@
 <%@tag import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@tag import="fr.cg44.plugin.socle.VideoUtils"%>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %><%
 %><%@ taglib uri="jcms.tld" prefix="jalios" %><%
 %><%@ tag 
@@ -6,7 +7,7 @@
     description="Titre du header simple" 
     body-content="scriptless" 
     import="com.jalios.jcms.Channel, com.jalios.util.ServletUtil, com.jalios.util.Util, com.jalios.jcms.JcmsUtil, 
-        com.jalios.jcms.taglib.ThumbnailTag, com.jalios.io.ImageFormat"
+        com.jalios.jcms.taglib.ThumbnailTag, com.jalios.io.ImageFormat, generated.Video, com.jalios.jcms.FileDocument"
 %>
 <%@ attribute name="title"
     required="true"
@@ -36,40 +37,12 @@
     type="String"
     description="Le chemin du fichier image mobile"
 %>
-<%@ attribute name="urlVideo"
-    required="false"
+<%@ attribute name="video"
+    required="true"
     fragment="false"
     rtexprvalue="true"
-    type="String"
-    description="L'URL de la vidéo"
-%>
-<%@ attribute name="titreVideo"
-    required="false"
-    fragment="false"
-    rtexprvalue="true"
-    type="String"
-    description="Le titre la vidéo"
-%>
-<%@ attribute name="fichierTranscript"
-    required="false"
-    fragment="false"
-    rtexprvalue="true"
-    type="String"
-    description="Le chemin du fichier de transcription"
-%>
-<%@ attribute name="typeFichierTranscript"
-    required="false"
-    fragment="false"
-    rtexprvalue="true"
-    type="String"
-    description="Le format du fichier de transcription"
-%>
-<%@ attribute name="tailleFichierTranscript"
-    required="false"
-    fragment="false"
-    rtexprvalue="true"
-    type="String"
-    description="La taille du fichier de transcription"
+    type="generated.Video"
+    description="Video"
 %>
 <%@ attribute name="alt"
     required="false"
@@ -118,6 +91,25 @@
 String userLang = Channel.getChannel().getCurrentUserLang();
 String uid = ServletUtil.generateUniqueDOMId(request, "uid");
 boolean hasFigcaption = Util.notEmpty(legend) || Util.notEmpty(copyright);
+
+//Récupération des infos de vidéo, dans la cas d'une fiche article ou actu
+String titreVideo = "";
+String urlVideo = "";
+String fichierTranscriptVideo = "";
+String typeFichierTranscript = "";
+String tailleFichierTranscript = "";
+if(Util.notEmpty(video)) {
+	titreVideo = video.getTitle();
+	urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(video.getUrlVideo()));
+	
+	// Récupération des infos du fichier de transcription
+	if(Util.notEmpty(video.getFichierTranscript())){
+		fichierTranscriptVideo = video.getFichierTranscript().getDownloadUrl();
+		typeFichierTranscript = FileDocument.getExtension(video.getFichierTranscript().getFilename()).toUpperCase();
+		tailleFichierTranscript = Util.formatFileSize(video.getFichierTranscript().getSize());
+	}
+}
+
 %>
 
 <div class="ds44-lightBG">
@@ -148,8 +140,8 @@ boolean hasFigcaption = Util.notEmpty(legend) || Util.notEmpty(copyright);
 	        <div class="ds44-inner-container">
 	            <div class="ds44-grid12-offset-1">
 	                <iframe title="<%= titreVideo %>" style="width: 100%; height: 480px; border: none;" src="<%= urlVideo %>" allowfullscreen></iframe>
-                    <jalios:if predicate="<%=Util.notEmpty(fichierTranscript)%>">
-				        <a href="<%= fichierTranscript %>" target="_blank" title="<%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript.title", titreVideo,typeFichierTranscript,tailleFichierTranscript) %>"><%= JcmsUtil.glp(userLang,"jcmsplugin.socle.video.telecharger-transcript.label") %></a>
+                    <jalios:if predicate="<%=Util.notEmpty(fichierTranscriptVideo)%>">
+				        <a href="<%= fichierTranscriptVideo %>" target="_blank" title="<%= JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript.title", titreVideo,typeFichierTranscript,tailleFichierTranscript) %>"><%= JcmsUtil.glp(userLang,"jcmsplugin.socle.video.telecharger-transcript.label") %></a>
 				    </jalios:if>
                 </div>
 	        </div>

--- a/plugins/SoclePlugin/types/FicheActu/doFicheActuFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheActu/doFicheActuFullDisplay.jsp
@@ -4,42 +4,13 @@
 %><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
 %><%@ include file='/jcore/doInitPage.jspf' %><%
 %><% FicheActu obj = (FicheActu)request.getAttribute(PortalManager.PORTAL_PUBLICATION); %><%
-%><%@ include file='/front/doFullDisplay.jspf' %><%
-%><% 
+%><%@ include file='/front/doFullDisplay.jspf' %>
 
-// Champs générés
-
-String lblFigure = "";
-if (Util.notEmpty(obj.getLegende())) lblFigure += obj.getLegende();
-if (Util.notEmpty(obj.getLegende()) && Util.notEmpty(obj.getCopyright())) lblFigure += " ";
-if (Util.notEmpty(obj.getCopyright())) lblFigure += glp("jcmsplugin.socle.symbol.copyright") + " " + obj.getCopyright();
- 
-// Récupération des infos de vidéo pour remplacer l'image, dans le titre.
- String urlVideo = "";
- String fichierTranscriptVideo = "";
- if(Util.notEmpty(obj.getVideoPrincipale())){
-   urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getVideoPrincipale().getUrlVideo()));
-   if(Util.notEmpty(obj.getVideoPrincipale().getFichierTranscript())){
-     fichierTranscriptVideo = obj.getVideoPrincipale().getFichierTranscript().getDownloadUrl();
-   }
- }
-%>
 <main id="content" role="main">
     <article class="ds44-container-large">
-        <ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= obj.getImageMobile() %>"
-            urlVideo="<%= urlVideo %>" fichierTranscript="<%=fichierTranscriptVideo %>" 
-            title="<%= obj.getTitle() %>" legend="<%= obj.getLegende() %>" 
-            copyright="<%= obj.getCopyright() %>" date='<%= SocleUtils.formatDate("dd/MM/yy", obj.getDateActu()) %>' 
-            alt="<%= obj.getTexteAlternatif() %>" breadcrumb="true"></ds:titleSimple>
-        <section class="ds44-contenuArticle">
-           <jalios:if predicate="<%= Util.notEmpty(obj.getChapo()) %>">
-           <div class="ds44-inner-container ds44-mtb3">
-                <div class="ds44-grid12-offset-2">
-                    <div class="ds44-introduction"><jalios:wysiwyg><%= obj.getChapo() %></jalios:wysiwyg></div>
-                </div>
-           </div>
-           </jalios:if>
-        </section>
+    
+    <%@ include file='../FicheArticle/commonTitreArticleActu.jspf' %>
+			
         <%-- Boucler sur les paragraphes --%>
         <jalios:foreach name="itTitle" type="String" counter="itCounter" array="<%= obj.getTitreParagraphe() %>">
            <jalios:if predicate="<%= itCounter <= obj.getContenuParagraphe().length && Util.notEmpty(obj.getContenuParagraphe()[itCounter-1]) %>">

--- a/plugins/SoclePlugin/types/FicheArticle/commonTitreArticleActu.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/commonTitreArticleActu.jspf
@@ -1,0 +1,18 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+
+<ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= obj.getImageMobile() %>" video="<%=obj.getVideoPrincipale() %>"
+    title="<%= obj.getTitle() %>" chapo="<%= obj.getChapo() %>" legend="<%= obj.getLegende() %>" copyright="<%= obj.getCopyright() %>" 
+    breadcrumb="true"></ds:titleSimple>
+
+<%-- Si vidéo au lieu de l'image, alors le chapo apparait au-dessus de la vidéo --%>
+<jalios:if predicate='<%=Util.isEmpty(obj.getVideoPrincipale()) && Util.notEmpty(obj.getChapo()) %>'>
+	<section class="ds44-contenuArticle">
+		<div class="ds44-inner-container ds44-mtb3">
+		    <div class="ds44-grid12-offset-2">
+				<div class="ds44-introduction">
+					<jalios:wysiwyg><%=obj.getChapo()%></jalios:wysiwyg>
+				</div>
+			</div>
+		</div>
+	</section>
+</jalios:if>

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
@@ -4,16 +4,8 @@
 %><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
 %><%@ include file='/jcore/doInitPage.jspf' %><%
 %><% FicheArticle obj = (FicheArticle)request.getAttribute(PortalManager.PORTAL_PUBLICATION); %><%
-%><%@ include file='/front/doFullDisplay.jspf' %><%
-%><% 
+%><%@ include file='/front/doFullDisplay.jspf' %>
 
-    // Champs générés
-
-    String lblFigure = "";
-    if (Util.notEmpty(obj.getLegende())) lblFigure += obj.getLegende();
-    if (Util.notEmpty(obj.getLegende()) && Util.notEmpty(obj.getCopyright())) lblFigure += " ";
-    if (Util.notEmpty(obj.getCopyright())) lblFigure += glp("jcmsplugin.socle.symbol.copyright") + " " + obj.getCopyright();
-%>
 <main id="content" role="main">
     <article class="ds44-container-large">
         <%-- Sélection qui dépend de l'image principale et du champ "Type d'article --%>

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
@@ -1,41 +1,7 @@
-<%
-// Rï¿½cupï¿½ration des infos de vidï¿½o, dans la cas d'une fiche article
-String titreVideo = "";
-String urlVideo = "";
-String fichierTranscriptVideo = "";
-String typeFichierTranscript = "";
-String tailleFichierTranscript = "";
-if(Util.notEmpty(obj.getVideoPrincipale())) {
-  titreVideo = obj.getVideoPrincipale().getTitle();
-  urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getVideoPrincipale().getUrlVideo()));
-  
-  // R�cup�ration des infos du fichier de transcription
-  if(Util.notEmpty(obj.getVideoPrincipale().getFichierTranscript())){
-    fichierTranscriptVideo = obj.getVideoPrincipale().getFichierTranscript().getDownloadUrl();
-    typeFichierTranscript = FileDocument.getExtension(obj.getVideoPrincipale().getFichierTranscript().getFilename()).toUpperCase();
-    tailleFichierTranscript = Util.formatFileSize(obj.getVideoPrincipale().getFichierTranscript().getSize());
-  }
-}
-%>
+<%@ page contentType="text/html; charset=UTF-8" %>
 
-<ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= obj.getImageMobile() %>" 
-    titreVideo="<%= titreVideo %>" urlVideo="<%= urlVideo %>" fichierTranscript="<%= fichierTranscriptVideo %>"
-    typeFichierTranscript="<%= typeFichierTranscript %>" tailleFichierTranscript="<%= tailleFichierTranscript %>"  
-    title="<%= obj.getTitle() %>" chapo="<%= obj.getChapo() %>" legend="<%= obj.getLegende() %>" copyright="<%= obj.getCopyright() %>" 
-    breadcrumb="true"></ds:titleSimple>
+<%@ include file='commonTitreArticleActu.jspf' %>
 
-<%-- Si vidéo au lieu de l'image, alors le chapo apparait au-dessus de la vidéo --%>
-<jalios:if predicate='<%=Util.isEmpty(urlVideo) && Util.notEmpty(obj.getChapo()) %>'>
-	<section class="ds44-contenuArticle">
-		<div class="ds44-inner-container ds44-mtb3">
-		    <div class="ds44-grid12-offset-2">
-				<div class="ds44-introduction">
-					<jalios:wysiwyg><%=obj.getChapo()%></jalios:wysiwyg>
-				</div>
-			</div>
-		</div>
-	</section>
-</jalios:if>
 <%-- Boucler sur les paragraphes --%>
 <jalios:foreach name="itParagraphe" type="String" counter="itCounter"
 	array="<%=obj.getContenuParagraphe()%>">

--- a/plugins/SoclePlugin/types/Video/doVideoFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Video/doVideoFullDisplay.jsp
@@ -6,27 +6,10 @@
 <% Video obj = (Video)request.getAttribute(PortalManager.PORTAL_PUBLICATION); %>
 <%@ include file='/front/doFullDisplay.jspf' %>
 
-<%
-String urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(obj.getUrlVideo()));
-FileDocument fichierTranscriptVideo = obj.getFichierTranscript();
-String cheminFichierTranscriptVideo = "";
-String typeFichierTranscript = "";
-String tailleFichierTranscript = "";
-
-// Récupération des infos du fichier de transcription
-if(Util.notEmpty(fichierTranscriptVideo)){
-  cheminFichierTranscriptVideo = fichierTranscriptVideo.getDownloadUrl();
-  typeFichierTranscript = FileDocument.getExtension(fichierTranscriptVideo.getFilename()).toUpperCase();
-  tailleFichierTranscript = Util.formatFileSize(fichierTranscriptVideo.getSize());
-}
-%>
-
 <main id="content" role="main">
     <article class="ds44-container-large">
-        <ds:titleSimple titreVideo="<%= obj.getTitle() %>" urlVideo="<%= urlVideo %>" fichierTranscript="<%= cheminFichierTranscriptVideo %>"
-            typeFichierTranscript="<%= typeFichierTranscript %>" tailleFichierTranscript="<%= tailleFichierTranscript %>"  
-            title="<%= obj.getTitle() %>" chapo="<%= obj.getChapo() %>" legend="<%= obj.getLegende() %>" copyright="<%= obj.getCopyright() %>" 
-            breadcrumb="true">
+        <ds:titleSimple video="<%= obj%>" title="<%= obj.getTitle() %>" chapo="<%= obj.getChapo() %>"
+            legend="<%= obj.getLegende() %>" copyright="<%= obj.getCopyright() %>" breadcrumb="true">
         </ds:titleSimple>
         <section class="ds44-contenuArticle">
             <div class="ds44-inner-container ds44-mtb3">


### PR DESCRIPTION
Mise en commun du code d'affichage du titre.
Refacto du tag "titleSimple" pour l'alléger. On lui passe en param l'objet Video plutot que les différents champs necessaires à l'affichage.