### PR TITLE
Refacto des tuiles Carrousel

### DIFF
--- a/WEB-INF/data/types/PortletCarousel/PortletCarousel.xml
+++ b/WEB-INF/data/types/PortletCarousel/PortletCarousel.xml
@@ -15,7 +15,7 @@
     <field name="contenusEnAvant" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.Content[]">
       <label xml:lang="fr">Contenus en avant</label>
     </field>
-    <field name="selectionDuTheme" editor="enumerate" required="true" compactDisplay="false" type="String" chooser="checkbox" valueList="darkContext|whiteContext" ml="false" descriptionType="tooltip" labelList="Fond gris, tuiles blanches|Fond blanc, tuiles grises" searchable="false" html="false" checkHtml="true">
+    <field name="selectionDuTheme" editor="enumerate" required="true" compactDisplay="false" type="String" chooser="checkbox" valueList="tuileVerticaleLight|tuileVerticaleDark" ml="false" descriptionType="tooltip" labelList="Fond gris, tuiles blanches|Fond blanc, tuiles grises" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Sélection du thème</label>
     </field>
     <field name="positionTitre" editor="enumerate" required="true" compactDisplay="false" type="String" chooser="listbox" valueList="none|tl|tr|bl|br" ml="false" descriptionType="text" searchable="false" html="false" checkHtml="true" labelList="Aucun|Haut gauche|Haut droit|Bas gauche|Bas droit">

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -49,7 +49,11 @@ jcmsplugin.socle.socialnetworks.title:Le Département de Loire-Atlantique sur
 # ------------------------------------------------------------
 #  Libellés communs
 # ------------------------------------------------------------
+jcmsplugin.socle.targetblank: target="_blank"
 jcmsplugin.socle.accessibily.newTabLabel: - nouvelle fenêtre
+jcmsplugin.socle.lien.site.nouvelonglet: Site web : {0} - nouvelle fenêtre
+jcmsplugin.socle.lien.document.nouvelonglet : {0} - {1} - {2} - nouvelle fenêtre
+jcmsplugin.socle.lien.nouvelonglet: {0} - nouvelle fenêtre
 jcmsplugin.charte.visible-topbar.group.name: Groupe pour la barre d'administration
 jcmsplugin.socle.menu: Menu
 jcmsplugin.socle.rechercher: Rechercher
@@ -65,7 +69,6 @@ jcmsplugin.socle.symbol.copyright: ©
 jcmsplugin.socle.illustration: illustration
 jcmsplugin.socle.navOnglet: Navigation des onglets
 jcmsplugin.socle.revenirOnglet: Revenir à l'onglet {0}
-jcmsplugin.socle.nouvelonglet: Ouvrir {0} dans un nouvel onglet
 jcmsplugin.socle.retourALaListe: Retour à la liste 
 jcmsplugin.socle.retourALaListeLieux: Retour à la liste des lieux
 jcmsplugin.socle.plusDeDetails: Plus de détails
@@ -99,6 +102,7 @@ jcmsplugin.socle.menu.principal1: Menu principal niveau 1
 jcmsplugin.socle.menu.principal2: Menu principal niveau 2
 jcmsplugin.socle.menu.navigation: Menu de navigation
 jcmsplugin.socle.sitesapplis: Sites et applis du Département
+jcmsplugin.socle.toussitesapplis: Tous nos sites et applis
 jcmsplugin.socle.sitesapplis.menu: Menu des sites et applications du Département
 jcmsplugin.socle.sitesapplis.menu.fermer: Fermer le menu des sites et applications
 jcmsplugin.socle.menu.pdcv: Près de chez vous

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -167,10 +167,11 @@ media.data-template.default.ListeDeContenus: /plugins/SoclePlugin/jsp/insertionU
 media.data-template.temoignage.Content: /plugins/SoclePlugin/jsp/templates/temoignageTemplate.jsp
 media.data-template.temoignage.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTemoignages.jsp
 media.data-template.contact.FicheLieu: /plugins/SoclePlugin/types/FicheLieu/doFicheLieuEmbedDisplayContent.jsp
-media.data-template.tuileHorizontaleGrey.Publication: /plugins/SoclePlugin/jsp/templates/tuileHorizontaleGrey.jsp
-media.data-template.tuileHorizontaleGrey.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileHorizontale.jsp
+media.data-template.tuileHorizontaleDark.Publication: /plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
+media.data-template.tuileHorizontaleDark.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileHorizontale.jsp
 media.data-template.plusRecherches.Lien: /plugins/SoclePlugin/jsp/templates/plusRecherche.jsp
-media.data-template.tuileVerticale.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
+media.data-template.tuileVerticaleDark.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
+media.data-template.tuileVerticaleLight.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp?context=dark
 media.data-template.tuileVerticale.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileVerticale.jsp
 
 # Content template - cards

--- a/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
@@ -14,7 +14,11 @@ String fileSize = "";
 String fileInfos = "";
 boolean targetBlank = false;
 String targetAttr = "";
-String titleAttr = "";
+String titleAttr = ""; // code HTML de l'attribut "title"
+String titleValue = ""; // valeur de l'attribut "title"
+String styleContext= Util.notEmpty(request.getParameter("context")) ? "ds44-darkContext" : "";
+String subTitle = "";
+String location = "";
    
 /* Le type de contenu "Lien" peut pointer vers une publication ou un site externe 
    Dans le cas d'une pub, si c'est un FileDoc alors on fait le lien direct sur le fichier,
@@ -28,21 +32,25 @@ if (isLien) {
 		FileDocument itDoc = (FileDocument) itLien.getLienInterne();
 		fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
 		fileSize = Util.formatFileSize(itDoc.getSize());
-		fileInfos = " - " + fileSize + " - " + fileType;
 		urlPub = itDoc.getDownloadUrl();
 		targetBlank = true;
+		titleValue = glp("jcmsplugin.socle.lien.document.nouvelonglet", itLien.getTitle(), fileSize, fileType);
       }else{
         urlPub = itLien.getLienInterne().getDisplayUrl(userLocale);
       }
   }else if (Util.notEmpty(itLien.getLienExterne())) {
     urlPub = itLien.getLienExterne();
     targetBlank = true;
+    titleValue = glp("jcmsplugin.socle.lien.site.nouvelonglet", itLien.getTitle());
   }
 }
 
-// Accessibilité : on place un attribut "title" sur le lien uniquement si le lien s'ouvre dans une nouvelle fenêtre
+/*  Accessibilité : on place un attribut "title" sur le lien uniquement si il s'ouvre dans une nouvelle fenêtre
+    Si lien externe : "Site web  : [Nom du lieu/établissement/entité/site web...] - nouvelle fenêtre"
+    Si doc : "[Titre du contenu] + poids + format - nouvelle fenêtre" 
+*/
 if(targetBlank){
-  targetAttr = "target=\"_blank\" ";
-  titleAttr = "title=\"" +  pub.getTitle() + fileInfos + " " + glp("jcmsplugin.socle.accessibily.newTabLabel")+"\"";
+  targetAttr = glp("jcmsplugin.socle.targetblank");
+  titleAttr = " title=\"" + HttpUtil.encodeForHTMLAttribute(titleValue) +"\" ";
   }
 %>

--- a/plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
@@ -9,6 +9,7 @@
 }
 
 Publication pub = (Publication) data;
+
 %>
 
 <%@include file="tuileCommon.jsp" %>
@@ -27,12 +28,24 @@ if (Util.isEmpty(urlImage)) {
     urlImage = (String) pub.getFieldValue("imageBandeau");
   } catch (Exception e) {}
 }
-if (Util.notEmpty(urlImage)) {
-  urlImage = SocleUtils.getUrlOfFormattedImageMobile(urlImage);
-}
+if (Util.isEmpty(urlImage)) {
+  urlImage = "s.gif";
+ } else {
+   urlImage = SocleUtils.getUrlOfFormattedImageMobile(urlImage);
+ }
+
+SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+
+try {
+    subTitle = sdf.format((Date) pub.getFieldValue("dateActu"));
+} catch(Exception e) {}
+
+try {
+    location = (String) pub.getFieldValue("lieu");
+} catch(Exception e) {}
 %>
 
-<section class="ds44-card ds44-js-card ds44-card--verticalPicture ds44-darkContext">
+<section class="ds44-card ds44-js-card ds44-card--verticalPicture <%=styleContext%>">
     <picture class="ds44-container-imgRatio">
         <img class="ds44-imgRatio" src="<%= urlImage %>" alt=''>
     </picture>
@@ -45,6 +58,14 @@ if (Util.notEmpty(urlImage)) {
         <jalios:if predicate="<%= isDoc %>">
             <p class="ds44-cardFile"><%= fileType %> - <%= fileSize %></p>
         </jalios:if>
+        <jalios:if predicate="<%= Util.notEmpty(subTitle) %>">
+            <p><%= subTitle %></p>
+        </jalios:if>
+        <jalios:if predicate="<%= Util.notEmpty(location) %>">
+            <p class="ds44-cardLocalisation">
+                <i class="icon icon-marker" aria-hidden="true"></i><span class="ds44-iconInnerText"><%= location %></span>
+            </p>
+        </jalios:if>        
         <i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>
     </div>
 </section>

--- a/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileHorizontale.jsp
+++ b/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileHorizontale.jsp
@@ -15,6 +15,6 @@ ListeDeContenus pub = (ListeDeContenus) data;
         <h2 class="h3-like"><%=pub.getLibelleTitre(userLang)%></h2>
 	</jalios:if>
 	<jalios:foreach name="itData" type="com.jalios.jcms.Content" array="<%= pub.getContenus() %>">
-        <jalios:media data='<%=itData %>' template='tuileHorizontaleGrey' />
+        <jalios:media data='<%=itData %>' template='tuileHorizontaleDark' />
     </jalios:foreach>
 </jalios:if>

--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
@@ -1,13 +1,13 @@
 <%
     PortletCarousel box = (PortletCarousel) portlet;
-    String themeSombre = "darkContext";
+    String themeClair = "tuileVerticaleLight";
     
     String titreBloc = Util.notEmpty(box.getTitreDuBloc()) ? box.getTitreDuBloc() : glp("jcmsplugin.socle.label.encemoment");
     String sousTitreBloc = box.getSoustitreDuBloc();
     String positionTitre = Util.notEmpty(box.getPositionTitre()) && !box.getPositionTitre().equals("none") ? "ds44-blockAbsolute--"+box.getPositionTitre() : "";
 %>
 
-<section class='ds44-container-fluid <%= box.getSelectionDuTheme().equals(themeSombre) ? " ds44-lightBG ds44-wave-white" : "" %> ds44--xxl-padding-tb'>
+<section class='ds44-container-fluid <%= box.getSelectionDuTheme().equals(themeClair) ? " ds44-lightBG ds44-wave-white" : "" %> ds44--xxl-padding-tb'>
     <div class="ds44-inner-container ds44--mobile--m-padding-b">
         <header class="txtcenter <%=Util.isEmpty(sousTitreBloc) ? "ds44-mb2" : ""%>">
             <h2 class="h2-like center"><%= titreBloc %></h2>
@@ -41,7 +41,9 @@
                 <%@ include file="/types/PortletQueryForeach/doSort.jspf"%>
                 <%@ include file="/types/PortletQueryForeach/doForeachHeader.jspf"%>
                 
-                <ds:tuileSlider pub="<%= itPub %>" theme="<%= box.getSelectionDuTheme() %>"/>
+                <li class="swiper-slide">
+                    <jalios:media data="<%=itPub %>" template="<%= box.getSelectionDuTheme() %>"/>
+                </li>
                 
                 <%@ include file="/types/PortletQueryForeach/doForeachFooter.jspf"%>
             </ul>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
@@ -31,12 +31,14 @@ String labelBouton = box.getLabelDuLien();
 String urlBouton = "";
 String targetAttr = "";
 String titleAttr = "";
+String titleValue = "";
 
 // Accessibilité : on place un attribut "title" sur le lien uniquement si le lien s'ouvre dans une nouvelle fenêtre
 if(isLienExterne){
   urlBouton = box.getLienExterne();
   targetAttr = glp("jcmsplugin.socle.targetblank");
-  titleAttr = "title=\"" +  labelBouton + glp("jcmsplugin.socle.accessibily.newTabLabel")+"\"";
+  titleValue = glp("jcmsplugin.socle.lien.site.nouvelonglet", labelBouton);
+  titleAttr = " title=\"" + HttpUtil.encodeForHTMLAttribute(titleValue) +"\" ";
 }
 else{
   urlBouton = box.getLienInterne().getDisplayUrl(userLocale);  

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrandsProjets.jsp
@@ -35,7 +35,7 @@ String titleAttr = "";
 // Accessibilité : on place un attribut "title" sur le lien uniquement si le lien s'ouvre dans une nouvelle fenêtre
 if(isLienExterne){
   urlBouton = box.getLienExterne();
-  targetAttr = "target=\"_blank\" ";
+  targetAttr = glp("jcmsplugin.socle.targetblank");
   titleAttr = "title=\"" +  labelBouton + glp("jcmsplugin.socle.accessibily.newTabLabel")+"\"";
 }
 else{
@@ -66,13 +66,13 @@ else{
 				<%-- Tuiles --%>
 				<div class="col-4 colFocusProjets">
 					<jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" max="<%= nbPubCol1 %>">
-	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+	                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleDark"/>
 					</jalios:foreach>
 				</div>
 				<jalios:if predicate='<%=nbPub > 1 %>'>
 		            <div class="col-4 colFocusProjets">
 		                <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" skip="<%= nbPubCol1 %>">
-		                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+		                    <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleDark"/>
 		                </jalios:foreach>
 		            </div>
                 </jalios:if>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrid.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrid.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %><%
 %><%@ include file='/jcore/doInitPage.jspf' %><%
 %><%@ include file='/jcore/portal/doPortletParams.jspf' %><%
+%><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
 %><% PortletMiseEnAvantDeContenus box = (PortletMiseEnAvantDeContenus)portlet; %><%
 List<Content> allContents = new ArrayList<>();
 if (Util.notEmpty(box.getFirstPublications())) {
@@ -29,7 +30,7 @@ if (Util.notEmpty(collection)) {
 		        <ul class="swiper-wrapper ds44-list grid-5-small-1 has-gutter-l ds44-carousel-swiper">
 		            <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>">
 		                <li class="swiper-slide">
-		                    <jalios:media data="<%= (Publication) itContent %>" template="tuileVerticale"/>
+                            <jalios:media data="<%=itContent %>" template="tuileVerticaleLight"/>
 		                </li>
 		            </jalios:foreach>
 		          
@@ -47,7 +48,7 @@ if (Util.notEmpty(collection)) {
     </div>
 
     <div class="txtcenter ds44-container-large ">
-      <button class="ds44-btnStd ds44-btnStd--large ds44-btnFullMobile" type="button" data-target="#overlay-sites-applis" data-js="ds44-modal"><span class="ds44-btnInnerText">Tous nos sites et applis</span><i class="icon icon-long-arrow-right" aria-hidden="true"></i></button>
+        <button class="ds44-btnStd ds44-btnStd--large ds44-btnFullMobile" type="button" data-target="#overlay-sites-applis" data-js="ds44-modal"><span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.toussitesapplis") %></span><i class="icon icon-long-arrow-right" aria-hidden="true"></i></button>
     </div>
 
 </section>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumn.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumn.jsp
@@ -20,6 +20,6 @@ if (Util.notEmpty(collection)) {
 <section id="services1clic_<%= box.getId() %>">
     <h2 class="h3-like"><%= box.getTitreVisuel() %></h2>
     <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>">
-        <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleGrey"/>
+        <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleDark"/>
     </jalios:foreach>
 </section>


### PR DESCRIPTION
Finalement, utilisation de media-template plutôt que le tag "tuileVerticale.tag", dans un soucis d'uniformisation, notamment p/r aux tuiles de résultats de recherche.
Renommage des media-template : quand la tuile est "dark" c'est qu'elle est dans un contexte "clair" et inversement.