### PR TITLE
Refacto (mini) encadrés Fiche Aide

### DIFF
--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
@@ -1,4 +1,5 @@
- <!-- Bon à savoir -->
+ <%@ page contentType="text/html; charset=UTF-8"%>
+ <%-- Bon à savoir --%>
 <jalios:if predicate="<%= Util.notEmpty(obj.getBonASavoir()) %>">
     <section class="ds44-box ds44-theme ds44-mb3">
         <div class="ds44-innerBoxContainer">
@@ -8,7 +9,7 @@
     </section>
 </jalios:if>              
 
-<!-- Témoignages -->
+<%-- Témoignages --%>
 <jalios:if predicate="<%= Util.notEmpty(obj.getVideo()) %>">
     <h2 class="h4-like ds44-box-heading"><%= Util.notEmpty(obj.getTitreVideo()) ? obj.getTitreVideo() : glp("jcmsplugin.socle.titre.temoignage") %></h2>
     <jalios:foreach name="itVideo" type="generated.Temoignage" array="<%= obj.getVideo() %>">
@@ -16,9 +17,7 @@
     </jalios:foreach>
 </jalios:if>
 
-
-
-<!-- Potlet encadrÃ©s -->
+<%-- Portlet encadrés --%>
 <jalios:if predicate="<%= Util.notEmpty(obj.getPortletEncadres()) %>">
 	<jalios:foreach array="<%= obj.getPortletEncadres() %>" name="itPortlet" type="Portlet">
 	    <jalios:include pub="<%= itPortlet %>" />

--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideEncadre.jspf
@@ -1,12 +1,19 @@
  <%@ page contentType="text/html; charset=UTF-8"%>
  <%-- Bon à savoir --%>
 <jalios:if predicate="<%= Util.notEmpty(obj.getBonASavoir()) %>">
-    <section class="ds44-box ds44-theme ds44-mb3">
-        <div class="ds44-innerBoxContainer">
-            <p role="heading" aria-level="2" class="ds44-box-heading"><%= Util.notEmpty(obj.getTitreEncartBonASavoir()) ? obj.getTitreEncartBonASavoir() : glp("jcmsplugin.socle.ficheaide.bonASavoir.label") %></p>
-            <jalios:wysiwyg><%= obj.getBonASavoir() %></jalios:wysiwyg>
-        </div>
-    </section>
+    <%-- On génère une section que si on a paramétré un titre, sinon on laisse le wysiwyg s'en charger --%>
+    <jalios:if predicate="<%=Util.notEmpty(obj.getTitreEncartBonASavoir())%>">
+	    <section class="ds44-box ds44-theme ds44-mb3">
+	        <div class="ds44-innerBoxContainer">
+	           <p role="heading" aria-level="2" class="ds44-box-heading"><%= Util.notEmpty(obj.getTitreEncartBonASavoir()) ? obj.getTitreEncartBonASavoir() : glp("jcmsplugin.socle.ficheaide.bonASavoir.label") %></p>
+    </jalios:if>
+    
+    <jalios:wysiwyg><%= obj.getBonASavoir() %></jalios:wysiwyg>
+            
+    <jalios:if predicate="<%=Util.notEmpty(obj.getTitreEncartBonASavoir())%>">            
+            </div>
+        </section>
+     </jalios:if>
 </jalios:if>              
 
 <%-- Témoignages --%>

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
@@ -1,17 +1,24 @@
+<%@page contentType="text/html; charset=UTF-8" %>
 <%@page import="generated.PortletWYSIWYG"%>
 
 <jalios:foreach array="<%=currentContenusEncadres%>" type="String"
 	name="itContenu" counter="itCounter">
-	<section class="ds44-box ds44-theme mbm">
-		<div class="ds44-innerBoxContainer">
-			<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
-				<p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
-			</jalios:if>
-			<jalios:wysiwyg>
-			 <div class="mts"><%=itContenu%></div>
-            </jalios:wysiwyg>
-		</div>
-	</section>
+	<%-- On génère une section que si on a paramétré un titre, sinon on laisse le wysiwyg s'en charger --%>
+	<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
+        <section class="ds44-box ds44-theme mbm">
+            <div class="ds44-innerBoxContainer">
+                <p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
+	</jalios:if>
+	
+	<jalios:wysiwyg>
+        <div class="mbm"><%=itContenu%></div>
+    </jalios:wysiwyg>
+          
+    <jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
+		  </div>
+	   </section>
+    </jalios:if>
+    
 </jalios:foreach>
 
 <jalios:foreach array="<%=currentContenusPortlets%>"

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
@@ -2,16 +2,24 @@
 
 <jalios:foreach array="<%=currentContenusEncadres%>" type="String"
 	name="itContenu" counter="itCounter">
-	<section class="ds44-box ds44-theme mbm">
-		<div class="ds44-innerBoxContainer">
-			<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
-				<p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
-			</jalios:if>
-			<jalios:wysiwyg>
-			 <div class="mts"><%=itContenu%></div>
-            </jalios:wysiwyg>
-		</div>
-	</section>
+	<%-- On génnère une section que si on a paramétré un titre, sinon on laisse le wysiwyg s'en charger --%>
+    <jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres)%>">
+        <section class="ds44-box ds44-theme mbm">
+            <div class="ds44-innerBoxContainer">
+    </jalios:if>
+
+	<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
+		<p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
+	</jalios:if>
+	<jalios:wysiwyg>
+        <div class="mts"><%=itContenu%></div>
+    </jalios:wysiwyg>
+          
+    <jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres)%>">            
+		  </div>
+	   </section>
+    </jalios:if>
+    
 </jalios:foreach>
 
 <jalios:foreach array="<%=currentContenusPortlets%>"

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
@@ -2,24 +2,16 @@
 
 <jalios:foreach array="<%=currentContenusEncadres%>" type="String"
 	name="itContenu" counter="itCounter">
-	<%-- On génnère une section que si on a paramétré un titre, sinon on laisse le wysiwyg s'en charger --%>
-    <jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres)%>">
-        <section class="ds44-box ds44-theme mbm">
-            <div class="ds44-innerBoxContainer">
-    </jalios:if>
-
-	<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
-		<p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
-	</jalios:if>
-	<jalios:wysiwyg>
-        <div class="mts"><%=itContenu%></div>
-    </jalios:wysiwyg>
-          
-    <jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres)%>">            
-		  </div>
-	   </section>
-    </jalios:if>
-    
+	<section class="ds44-box ds44-theme mbm">
+		<div class="ds44-innerBoxContainer">
+			<jalios:if predicate="<%=Util.notEmpty(currentTitresEncadres) && currentTitresEncadres.length > itCounter-1 && Util.notEmpty(currentTitresEncadres[itCounter - 1]) %>">
+				<p class="ds44-box-heading" role="heading" aria-level="2"><%=currentTitresEncadres[itCounter - 1]%></p>
+			</jalios:if>
+			<jalios:wysiwyg>
+			 <div class="mts"><%=itContenu%></div>
+            </jalios:wysiwyg>
+		</div>
+	</section>
 </jalios:foreach>
 
 <jalios:foreach array="<%=currentContenusPortlets%>"

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleEncadre.jspf
@@ -23,15 +23,6 @@
 
 <jalios:foreach array="<%=currentContenusPortlets%>"
 	type="PortalElement" name="itPortalElem">
-	<jalios:if predicate="<%=itPortalElem instanceof PortletWYSIWYG%>">
-		<%
-			PortletWYSIWYG itWysiwyg = (PortletWYSIWYG) itPortalElem;
-		%>
-		<section class="ds44-box mbm <%= itWysiwyg.getCssClasses() %>">
-			<div class="ds44-innerBoxContainer">
-				<p class="ds44-box-heading" role="heading" aria-level="2"><%=itWysiwyg.getTitle()%></p>
-				<div class="mts"><%=itWysiwyg.getWysiwyg()%></div>
-			</div>
-		</section>
-	</jalios:if>
+	<jalios:include pub="<%= itPortalElem %>" />
+
 </jalios:foreach>


### PR DESCRIPTION
Commentaire JAVA plutôt que HTML : il y avait des caractère mal encodés dans le source et ça ne plaisait pas au validateur W3C. Du coup j'ai rajouté l'encodage UTF8.