### PR TITLE
Refacto champs de formulaires : remplacement des div en span

### DIFF
--- a/plugins/SoclePlugin/jsp/portlet/portletFacetteAutoCompletion.jspf
+++ b/plugins/SoclePlugin/jsp/portlet/portletFacetteAutoCompletion.jspf
@@ -30,11 +30,11 @@
 
 	
 					<label for='<%= idFormElement %>' class="ds44-formLabel">
-					    <div class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
+					    <span class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
 							<span>
 								<%= label %><%= obj.getFacetteObligatoire() ? "<sup aria-hidden=\"true\">*</sup>" : "" %>
 							</span>
-						</div>
+						</span>
 					</label>
 					<input class="ds44-input-value" type="hidden" value="">
 					<input class="ds44-input-metadata" type="hidden" aria-hidden="true" value="">
@@ -192,11 +192,11 @@
 				<div class="ds44-form__container">
 
 					   <label for='<%= "option-" + idFormElement %>' class="ds44-formLabel ds44-inputDisabled">
-							<div class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
+							<span class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
 								<span>
 									<%= glp("jcmsplugin.socle.facette.adresse.default-label") %><%= obj.getFacetteObligatoire() ? "<sup aria-hidden=\"true\">*</sup>" : "" %>
 								</span>
-							</div> 
+							</span> 
 						</label>
 						<input class="ds44-input-value" type="hidden" value="">
 						<input class="ds44-input-metadata" type="hidden" value="">
@@ -240,11 +240,11 @@
 
 	<div class="ds44-form__container">
 			<label for='<%= idFormElement %>' class="ds44-formLabel">
-		        <div class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
+		        <span class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
 					<span>
 						<%= label %><%= obj.getFacetteObligatoire() ? "<sup aria-hidden=\"true\">*</sup>" : "" %>
 					</span>
-				</div>
+				</span>
 			</label>
 			
 			<input type="text" id='<%= idFormElement %>' class='<%= "ds44-inp" + styleChamps %>' role="combobox" 

--- a/plugins/SoclePlugin/types/FaqAccueil/doFaqAccueilFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FaqAccueil/doFaqAccueilFullDisplay.jsp
@@ -62,11 +62,11 @@
 					<div class="ds44-form__container">
 						<div class="ds44-posRel">
 							<label for="form-element-10988" class="ds44-formLabel">
-                                <div class="ds44-labelTypePlaceholder">
+                                <span class="ds44-labelTypePlaceholder">
 									<span class="ds44-labelTypePlaceholder">
 										<%= glp("jcmsplugin.socle.faq.votre-question") %><sup aria-hidden="true">*</sup>
 									</span>
-								</div>
+								</span>
 							</label>
 							<textarea rows="5" cols="1" id="form-element-10988" class="ds44-inpStd" 
 									title='<%= glp("jcmsplugin.socle.faq.votre-question") %> - <%= glp("jcmsplugin.socle.obligatoire") %>'
@@ -77,9 +77,9 @@
 					<div class="ds44-form__container">
 						<div class="ds44-posRel">
 							<label for="form-element-26867" class="ds44-formLabel">
-                                <div class="ds44-labelTypePlaceholder">
+                                <span class="ds44-labelTypePlaceholder">
 								    <span class="ds44-labelTypePlaceholder"><%= glp("jcmsplugin.socle.pdcv.votrecommune") %></span>
-                                </div>
+                                </span>
 							</label>
 							<input type="text" id="form-element-77221" name="commune" class="ds44-inpStd" 
 									role="combobox" 
@@ -107,11 +107,11 @@
 					<div class="ds44-form__container">
 						<div class="ds44-posRel">
 							<label for="form-element-99423" class="ds44-formLabel">
-                                <div class="ds44-labelTypePlaceholder">
+                                <span class="ds44-labelTypePlaceholder">
 									<span class="ds44-labelTypePlaceholder">
 										<%= glp("jcmsplugin.socle.faq.votre-email") %><sup aria-hidden="true">*</sup>
 									</span>
-                                </div>
+                                </span>
 							</label>
 							<input type="text" id="form-element-42259" name="form-element-42259" class="ds44-inpStd" 
 									title='<%= glp("jcmsplugin.socle.faq.votre-email") %> - <%= glp("jcmsplugin.socle.obligatoire") %>' 

--- a/plugins/SoclePlugin/types/PortletFacetteMotcle/doPortletFacetteMotcleBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteMotcle/doPortletFacetteMotcleBoxDisplay.jsp
@@ -13,11 +13,11 @@
 
 <div class="ds44-form__container">
 	   <label for='<%= idFormElement %>' class="ds44-formLabel">
-	        <div class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
+	        <span class='<%= "ds44-labelTypePlaceholder ds44-labelTypePlaceholder" + styleChamps2 %>'>
 				<span>
 					<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : "Mot clé"%><%= obj.getFacetteObligatoire() ? "<sup aria-hidden=\"true\">*</sup>" : "" %>
 				</span>
-			</div>
+			</span>
 		</label>
 		<input name='<%= "text" + idFormElement %>' type="text" id='<%= idFormElement %>' class='<%= "ds44-inp" + styleChamps %>' 
 				<%= obj.getFacetteObligatoire() ? "required aria-required=\"true\"" : ""%> />


### PR DESCRIPTION
Sous les label de formulaire pour coller au DS.
Note : certains formulaires étaient déjà en span ce qui explique que peu de fichiers sont impactés.