### PR TITLE
Fix fiche SAAD : ajout d'infobulles

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -421,6 +421,7 @@
     <file path="WEB-INF/tags/titleNoImage.tag" />
     <file path="WEB-INF/tags/tuileSlider.tag" />
     <file path="WEB-INF/tags/toggle.tag" />
+    <file path="WEB-INF/tags/tooltip.tag" />
     <file path="jcore/doEmptyHeader.jspf" />
     <file path="jcore/doEmptyFooter.jspf" />
   </webapp-files>  

--- a/WEB-INF/tags/categoryTree.tag
+++ b/WEB-INF/tags/categoryTree.tag
@@ -1,0 +1,103 @@
+<%@tag import="generated.PortletPortalRedirect"%>
+<%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %><%
+%><%@ taglib uri="jcms.tld" prefix="jalios" %><%
+%><%@ tag 
+    pageEncoding="UTF-8"
+    description="Liste des catégories et leurs enfants sur un nobre de niveau donné" 
+    body-content="scriptless" 
+    import="com.jalios.jcms.Channel,
+            com.jalios.jcms.Category,
+            com.jalios.jcms.Member,
+            com.jalios.jcms.Publication,
+            com.jalios.jcms.DataSelector,
+            com.jalios.jcms.JcmsUtil,
+            com.jalios.util.ServletUtil,
+            com.jalios.util.Util,
+            java.util.TreeSet,
+            java.util.Set,
+            java.util.Locale,
+            fr.cg44.plugin.socle.SocleUtils,
+            generated.PageCarrefour"
+%><%
+%><%@ attribute name="rootCat"
+    required="true"
+    fragment="false"
+    rtexprvalue="true"
+    type="com.jalios.jcms.Category"
+    description="Catégorie racine sur laquelle itérer pour générer la liste"
+%><%
+%><%@ attribute name="maxLevels"
+    required="true"
+    fragment="false"
+    rtexprvalue="true"
+    type="Integer"
+    description="Niveau max de profondeur de l'arbre"
+%><%
+%><%@ attribute name="currentLevel"
+required="false"
+fragment="false"
+rtexprvalue="true"
+type="Integer"
+description="Niveau courant de l'arbre"%>
+
+<%
+Member loggedMember = Channel.getChannel().getCurrentJcmsContext().getLoggedMember();
+String userLang = Channel.getChannel().getCurrentJcmsContext().getUserLang();
+Locale userLocale = Channel.getChannel().getCurrentJcmsContext().getUserLocale();
+
+// Tri des catégories filles + filtre sur catégories autorisées
+Set<Category> childrenCatSet = SocleUtils.getOrderedAuthorizedChildrenSet(rootCat);
+
+// Calcul du niveau d'itération courant
+int itLevel = currentLevel!=null ? currentLevel : 0;
+itLevel++;
+
+// Style pour le padding des listes imbriquées (padding doublé au-delà du niveau 1)
+String paddingClass = "ds44-list ds44-collapser_content--level2";
+%>
+<jalios:if predicate="<%= !childrenCatSet.isEmpty() && itLevel <= maxLevels  %>">
+    <% if(itLevel>1) paddingClass = "ds44-list ds44-collapser_content--level3"; %>
+    <ul class="<%=paddingClass%>">
+    <%-- Si présence d'un contenu principal dans la catégorie, alors lien vers ce contenu, sinon génération des enfants. --%>
+    <%
+	for(Category itCategory : childrenCatSet){
+		String cible= "";
+		String title = "";
+		String libelleCat = Util.notEmpty(itCategory.getExtraData("extra.Category.plugin.tools.synonyme.facet.title")) ? itCategory.getExtraData("extra.Category.plugin.tools.synonyme.facet.title") : itCategory.getName(userLang);
+		boolean targetBlank = "true".equals(itCategory.getExtraData("extra.Category.plugin.tools.blank")) ? true : false;
+		if(targetBlank){
+		    cible="target=\"_blank\" ";
+		    title = "title=\"" + libelleCat + " " + JcmsUtil.glp(userLang, "jcmsplugin.socle.accessibily.newTabLabel")+"\"";
+		}
+		
+		Publication itContenuPrincipal = SocleUtils.getContenuPrincipal(itCategory);
+		PortletPortalRedirect itRedirect = SocleUtils.getPortalRedirect(itCategory);
+	    if(Util.notEmpty(itContenuPrincipal)) {%>
+	    	<li><a href="<%= itContenuPrincipal.getDisplayUrl(userLocale) %>" class="ds44-collapser_content--link" <%=title%> <%=cible%>><%=libelleCat%></a></li>
+	    <%}
+	    else if (Util.notEmpty(itRedirect)) {%>
+	       <jalios:select>
+               <jalios:if predicate='<%= itRedirect.getStatus().equals("url") && Util.notEmpty(itRedirect.getUrl()) %>'>
+	           <li><a target="_blank" href="<%= itCategory.getDisplayUrl(userLocale) %>" class="ds44-collapser_content--link" <%=title%> <%=cible%>><%=libelleCat%></a></li>
+	           </jalios:if>
+	           <jalios:default>
+	           <li><a href="<%= itCategory.getDisplayUrl(userLocale) %>" class="ds44-collapser_content--link" <%=title%> <%=cible%>><%=libelleCat%></a></li>
+	           </jalios:default>
+	       </jalios:select>
+	    <%}
+        else {%>
+	       <li>
+	           <jalios:select>
+		           <jalios:if predicate="<%= Util.notEmpty(itCategory.getChildrenSet()) %>">
+			           <span class="ds44-collapser_content--txt"><%=libelleCat%></span>
+		               <ds:categoryTree rootCat='<%=itCategory %>' maxLevels="<%=maxLevels%>" currentLevel="<%=itLevel%>"/>
+		           </jalios:if>
+		           <jalios:default>
+		               <a href="<%= itCategory.getDisplayUrl(userLocale) %>" class="ds44-collapser_content--link" <%=title%> <%=cible%>><%=libelleCat%></a>
+		           </jalios:default>
+	           </jalios:select>
+           </li><%
+	    }
+	}%>
+    </ul>
+</jalios:if>

--- a/WEB-INF/tags/tooltip.tag
+++ b/WEB-INF/tags/tooltip.tag
@@ -1,0 +1,55 @@
+<%@ taglib uri="jcms.tld" prefix="jalios" %>
+<%@ tag 
+    pageEncoding="UTF-8"
+    description="Affiche une infobulle avec, soit le texte passé en paramètre, soit la description de la catégorie passée en paramètre" 
+    body-content="scriptless" 
+    import="com.jalios.jcms.Channel, com.jalios.util.ServletUtil, com.jalios.util.Util"
+%>
+<%@ attribute name="cat"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="com.jalios.jcms.Category"
+    description="La catégorie dont on souhaite afficher la description dans l'infobulle"
+%>
+<%@ attribute name="help"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le texte d'aide pour le bouton d'infobulle"
+%>
+<%@ attribute name="text"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le contenu de l'infobulle (si catégorie absente)"
+%>
+
+<% 
+String uid = ServletUtil.generateUniqueDOMId(request, "uid");
+String userLang = Channel.getChannel().getCurrentJcmsContext().getUserLang();
+
+/* Si le texte est vide on regarde si la catégorie possède une description et une autorisation d'affichage de tooltip.
+ * Si on ne trouve rien, on n'affiche rien.
+*/
+String tooltipContent = text;
+if(Util.isEmpty(tooltipContent)){
+	if(Util.notEmpty(cat) && Boolean.parseBoolean(cat.getExtraData("extra.Category.plugin.tools.tooltip")) && Util.notEmpty(cat.getDescription(userLang))){
+		tooltipContent = cat.getDescription(userLang);
+  	}
+	if(Util.isEmpty(tooltipContent)){
+		return;
+	}
+}
+%>
+
+<button type="button" class="js-simple-tooltip button" data-simpletooltip-content-id="tooltip_<%= uid %>">
+    <i class="icon icon-help" aria-hidden="true"></i>
+    <jalios:if predicate='<%= Util.notEmpty(help) %>'>
+        <span class="visually-hidden"><%= help %></span>
+    </jalios:if>
+</button>
+<span id="tooltip_<%= uid %>" class="simpletooltip js-simple-tooltip" role="tooltip" aria-hidden="true"><%= tooltipContent %></span>
+

--- a/WEB-INF/tags/tooltip.tag
+++ b/WEB-INF/tags/tooltip.tag
@@ -34,6 +34,8 @@ String userLang = Channel.getChannel().getCurrentJcmsContext().getUserLang();
 /* Si le texte est vide on regarde si la catégorie possède une description et une autorisation d'affichage de tooltip.
  * Si on ne trouve rien, on n'affiche rien.
 */
+System.out.println(cat.getName());
+System.out.println(help);
 String tooltipContent = text;
 if(Util.isEmpty(tooltipContent)){
 	if(Util.notEmpty(cat) && Boolean.parseBoolean(cat.getExtraData("extra.Category.plugin.tools.tooltip")) && Util.notEmpty(cat.getDescription(userLang))){

--- a/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
@@ -91,12 +91,12 @@ String localisation = SocleUtils.formatOpenStreetMapLink(latitude, longitude);
 			            <div class="col mls ds44-mtb3">
 			              <h2 class="h3-like" id="idTitre-list2"><%= glp("jcmsplugin.socle.fichesaad.detail") %></h2>
 			              <ul class="ds44-uList">
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.statut") %></strong> <%= SocleUtils.formatCategories(obj.getStatutJuridique(loggedMember)) %></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.plageintervention") %></strong> <%= SocleUtils.formatCategories(obj.getPlagesDintervention(loggedMember)) %></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.typeaide") %></strong> <%= SocleUtils.formatCategories(obj.getTypeDaide(loggedMember)) %></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modalitespaiement") %></strong> <%= SocleUtils.formatCategories(obj.getModalitesDePaiement(loggedMember)) %></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modesintervention") %></strong> <span><%= SocleUtils.formatCategories(obj.getModesDintervention(loggedMember)) %></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modetarification") %></strong> <%= SocleUtils.formatCategories(obj.getModeDeTarification(loggedMember)) %></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.statut") %></strong> <%= SocleUtils.formatCategories(obj.getStatutJuridique(loggedMember)) %><ds:tooltip cat="<%= obj.getStatutJuridique(loggedMember).first().getParent() %>" text="test"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.plageintervention") %></strong> <%= SocleUtils.formatCategories(obj.getPlagesDintervention(loggedMember)) %><ds:tooltip cat="<%= obj.getPlagesDintervention(loggedMember).first().getParent() %>"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.typeaide") %></strong> <%= SocleUtils.formatCategories(obj.getTypeDaide(loggedMember)) %><ds:tooltip cat="<%= obj.getTypeDaide(loggedMember).first().getParent() %>"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modalitespaiement") %></strong> <%= SocleUtils.formatCategories(obj.getModalitesDePaiement(loggedMember)) %><ds:tooltip cat="<%= obj.getModalitesDePaiement(loggedMember).first().getParent() %>"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modesintervention") %></strong> <span><%= SocleUtils.formatCategories(obj.getModesDintervention(loggedMember)) %><ds:tooltip cat="<%= obj.getModesDintervention(loggedMember).first().getParent() %>"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modetarification") %></strong> <%= SocleUtils.formatCategories(obj.getModeDeTarification(loggedMember)) %><ds:tooltip cat="<%= obj.getModeDeTarification(loggedMember).first().getParent() %>"/></li>
 			              </ul>
 			            </div>
 			            

--- a/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
@@ -91,12 +91,12 @@ String localisation = SocleUtils.formatOpenStreetMapLink(latitude, longitude);
 			            <div class="col mls ds44-mtb3">
 			              <h2 class="h3-like" id="idTitre-list2"><%= glp("jcmsplugin.socle.fichesaad.detail") %></h2>
 			              <ul class="ds44-uList">
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.statut") %></strong> <%= SocleUtils.formatCategories(obj.getStatutJuridique(loggedMember)) %><ds:tooltip cat="<%= obj.getStatutJuridique(loggedMember).first().getParent() %>" text="test"/></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.plageintervention") %></strong> <%= SocleUtils.formatCategories(obj.getPlagesDintervention(loggedMember)) %><ds:tooltip cat="<%= obj.getPlagesDintervention(loggedMember).first().getParent() %>"/></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.typeaide") %></strong> <%= SocleUtils.formatCategories(obj.getTypeDaide(loggedMember)) %><ds:tooltip cat="<%= obj.getTypeDaide(loggedMember).first().getParent() %>"/></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modalitespaiement") %></strong> <%= SocleUtils.formatCategories(obj.getModalitesDePaiement(loggedMember)) %><ds:tooltip cat="<%= obj.getModalitesDePaiement(loggedMember).first().getParent() %>"/></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modesintervention") %></strong> <span><%= SocleUtils.formatCategories(obj.getModesDintervention(loggedMember)) %><ds:tooltip cat="<%= obj.getModesDintervention(loggedMember).first().getParent() %>"/></li>
-			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modetarification") %></strong> <%= SocleUtils.formatCategories(obj.getModeDeTarification(loggedMember)) %><ds:tooltip cat="<%= obj.getModeDeTarification(loggedMember).first().getParent() %>"/></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.statut") %></strong> <ds:categoryList categories="<%= obj.getStatutJuridique(loggedMember) %>" tooltip="true" /></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.plageintervention") %></strong> <ds:categoryList categories="<%= obj.getPlagesDintervention(loggedMember) %>" tooltip="true" /></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.typeaide") %></strong> <ds:categoryList categories="<%= obj.getTypeDaide(loggedMember) %>" tooltip="true" /></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modalitespaiement") %></strong> <ds:categoryList categories="<%= obj.getModalitesDePaiement(loggedMember) %>" tooltip="true" /></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modesintervention") %></strong> <ds:categoryList categories="<%= obj.getModesDintervention(loggedMember) %>" tooltip="true" /></li>
+			                <li><strong><%= glp("jcmsplugin.socle.fichesaad.modetarification") %></strong> <ds:categoryList categories="<%= obj.getModeDeTarification(loggedMember) %>" tooltip="true" /></li>
 			              </ul>
 			            </div>
 			            

--- a/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateMenuCollapseFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateMenuCollapseFullDisplay.jsp
@@ -49,7 +49,7 @@ Set<Category> level1CatSet = SocleUtils.getOrderedAuthorizedChildrenSet(itCatLev
 		      <c:set var="itCategory" value="<%=itCatLevel2%>" scope="request"/>
 		      <c:set var="maxLevels" value="<%=maxLevels%>" scope="request"/>
 		      <ds:toggle title="<%=itCatLevel2.getName() %>">
-		          <ds:categoryList rootCat="${itCategory}" maxLevels="${maxLevels}" currentLevel="0" />
+		          <ds:categoryTree rootCat="${itCategory}" maxLevels="${maxLevels}" currentLevel="0" />
 		      </ds:toggle><%
 		    }else {%>
 		    	<jalios:link data="<%=itCatLevel2%>" css="ds44-collapser_content--buttonLike"><%=itCatLevel2.getName()%></jalios:link>


### PR DESCRIPTION
- création du tag "tooltip"
- mise en place pour les catégories de la fiche SAAD
- refacto : renommage du tag categoryList.tag en categoryTree.tag
- le tag categoryList.tag affiche désormais une liste de catégories avec séparateur et la possibilité d'afficher une infobulle.