### PR TITLE
Evol : contenu non répertorié

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
@@ -1032,8 +1032,8 @@ public final class SocleUtils {
    * @return <code>true</code> si la publication doit être masquée sinon <code>false</code> 
    * 
    */
-  public static boolean isInvisible(Publication pub) {
-  	return pub.containsCategory(channel.getCategory("$jcmsplugin.socle.recherche.invisible.cat"));
+  public static boolean isNonRepertoriee(Publication pub) {
+  	return pub.containsCategory(channel.getCategory("$jcmsplugin.socle.recherche.nonrepertoriee.cat"));
   }  
 	
 }

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -50,7 +50,7 @@ jcmsplugin.socle.js-urls:https://design.loire-atlantique.fr/js/cd44.js
 # ------------------------------------------------------------
 $jcmsplugin.socle.recherche.facettes.portal: c_1273916
 # Les contenus ayant cette catégorie de classement ne remonteront pas dans les moteurs de recherche.
-$jcmsplugin.socle.recherche.invisible.cat: c_1274159
+$jcmsplugin.socle.recherche.nonrepertoriee.cat: c_1274159
 
 # ------------------------------------------------------------
 #  Formats d'images

--- a/plugins/SoclePlugin/types/FicheLieu/doFicheLieuEmbedDisplayContent.jsp
+++ b/plugins/SoclePlugin/types/FicheLieu/doFicheLieuEmbedDisplayContent.jsp
@@ -14,13 +14,13 @@ String longitude = obj.getExtraData("extra.FicheLieu.plugin.tools.geolocation.lo
 String latitude = obj.getExtraData("extra.FicheLieu.plugin.tools.geolocation.latitude");
 String localisation = SocleUtils.formatOpenStreetMapLink(latitude, longitude);
 String adresseEcrire = SocleUtils.formatAdresseEcrire(obj);
-boolean invisiblePub = SocleUtils.isInvisible(obj);
+boolean pubNonRepertoriee = SocleUtils.isNonRepertoriee(obj);
 %>
 <section class="pbm">
 	<p class="ds44-docListElem mtm" role="heading" aria-level="3">
 	    <strong><i class="icon icon-user ds44-docListIco" aria-hidden="true"></i>
 	       <jalios:select>
-	           <jalios:if predicate='<%= invisiblePub %>'>
+	           <jalios:if predicate='<%= pubNonRepertoriee %>'>
 	               <%= obj.getTitle() %>
 	           </jalios:if>
 	               


### PR DESCRIPTION
Renommage de la méthode.
Cette méthode regarde juste si la publication a été mise dans la catégorie de classement "Contenu non répertorié".
Ca m'a servi pour les tuile de contacts et servira pour le moteur de recherche.