### PR TITLE
Fix header : gestion d'un logo mobile / desktop

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -33,6 +33,7 @@ jcmsplugin.socle.footer.portletcontact.id : c_1275593
 #  Header
 # ------------------------------------------------------------
 jcmsplugin.socle.site.src.logo: https://design.loire-atlantique.fr/assets/images/logo-loire-atlantique.svg
+jcmsplugin.socle.site.src.logomobile:
 jcmsplugin.socle.site.src.carte.pdcv: https://design.loire-atlantique.fr/assets/images/cd44-carte-secteurs-desktop.svg
 jcmsplugin.socle.site.src.carte.pdcv.mobile: https://design.loire-atlantique.fr/assets/images/cd44-carte-secteurs-mobile.svg
 jcmsplugin.socle.site.header.cat: 

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -5,7 +5,7 @@
 <%@ page import="fr.cg44.plugin.socle.SocleUtils"%>
 
 
-<%
+<%logger.warn(channel.getProperty("jcmsplugin.socle.site.src.logomobile"));
 String[] headerCatListId = channel.getStringArrayProperty("jcmsplugin.socle.site.header.cat", new String[] {});
 Category[] headerCatList = JcmsUtil.stringArrayToDataArray (Category.class, headerCatListId);
 
@@ -36,7 +36,11 @@ boolean displaySearchMenu = channel.getBooleanProperty("jcmsplugin.socle.site.he
                 <div class="ds44-colLeft">
                     <a href="index.jsp" class="ds44-logoContainer">
                         <picture class="ds44-logo">
-                            <img src="<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>" alt="<%= glp("jcmsplugin.socle.retour.accueil") %> <%=channel.getName() %>" />
+                            <jalios:if predicate='<%= Util.notEmpty(channel.getProperty("jcmsplugin.socle.site.src.logomobile")) %>'>
+                                <source media='(max-width: 47.9375em)' srcset='<%= channel.getProperty("jcmsplugin.socle.site.src.logomobile") %>'>
+                                <source media='(min-width: 47.9375em)' srcset='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>'>
+                            </jalios:if>
+                            <img src='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>' alt="<%= HttpUtil.encodeForHTMLAttribute(glp("jcmsplugin.socle.retour.accueil")) %> <%=channel.getName() %>" />
                         </picture>
                     </a>
                 </div>

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -5,7 +5,7 @@
 <%@ page import="fr.cg44.plugin.socle.SocleUtils"%>
 
 
-<%logger.warn(channel.getProperty("jcmsplugin.socle.site.src.logomobile"));
+<%
 String[] headerCatListId = channel.getStringArrayProperty("jcmsplugin.socle.site.header.cat", new String[] {});
 Category[] headerCatList = JcmsUtil.stringArrayToDataArray (Category.class, headerCatListId);
 


### PR DESCRIPTION
Si présence d'une propriété avec un logo mobile alors on génère les 2 balise <source> dans la balise <picture> utilisée pour l'affichage du logo.
Si absent alors on génère uniquement la balise <img>.
Dans le cas du site handicap la propriété sera mise directement dans le custom.prop