### PR TITLE
Evol fiche article

### DIFF
--- a/WEB-INF/data/types/FicheArticle/FicheArticle.xml
+++ b/WEB-INF/data/types/FicheArticle/FicheArticle.xml
@@ -37,6 +37,9 @@
     <field name="chapo" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="true" rows="5" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true">
       <label xml:lang="fr">Chapo</label>
     </field>
+    <field name="infobulleAnnuaire" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="true" rows="4" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true">
+      <label xml:lang="fr">Infobulle annuaire</label>
+    </field>      
     <field name="typeSimple" editor="boolean" required="false" compactDisplay="false" type="boolean" default="true" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Type</label>
       <onLabel xml:lang="en">Yes</onLabel>
@@ -64,9 +67,6 @@
     <field name="contenuParagraphe" editor="wysiwyg" required="false" compactDisplay="false" tab="contenu" type="String[]" searchable="true" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" inline="true" tabGroup="Paragraphe">
       <label xml:lang="fr">Contenu paragraphe</label>
     </field>
-    <field name="bottomportlets" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.portlet.PortalElement[]" parent="false" ml="false" descriptionType="tooltip" tab="contenu" searchable="false" html="false" checkHtml="true" hidden="true">
-      <label xml:lang="fr">Portlets bas</label>
-    </field>    
     <field name="titreOnglet_1" editor="textfield" required="false" compactDisplay="false" tab="onglet_1" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="true" descriptionType="tooltip">
       <label xml:lang="fr">Titre onglet</label>
     </field>
@@ -178,6 +178,15 @@
     <field name="cantons" editor="link" required="false" compactDisplay="false" tab="territoire" type="generated.Canton[]" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Cantons concernés</label>
     </field>
+    <field name="bottomportlets" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.portlet.PortalElement[]" parent="false" ml="false" descriptionType="tooltip" tab="contenu" searchable="false" html="false" checkHtml="true" hidden="true">
+      <label xml:lang="fr">Portlets bas</label>
+    </field>
+    <field name="sideportlets" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.portlet.PortalElement[]" parent="false" ml="false" descriptionType="tooltip" tab="contenu" searchable="false" html="false" checkHtml="true" hidden="true">
+      <label xml:lang="fr">Portlets encadrés (article simple uniquement)</label>
+    </field>     
+    <field name="idAncienContenu" editor="textfield" required="false" compactDisplay="false" type="String" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true" hidden="true">
+      <label xml:lang="fr">ID ancien contenu (si cet article a fait l'objet d'une reprise)</label>
+    </field>     
   </fields>
   <tabs>
     <tab id="contenu">

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
@@ -10,6 +10,10 @@
     <article class="ds44-container-large">
         <%-- Sélection qui dépend de l'image principale et du champ "Type d'article --%>
         <jalios:select>
+            <jalios:if predicate="<%=Util.notEmpty(obj.getSideportlets())%>">
+                <%-- Include du gabarit technique (formulaire contact par ex) --%>
+                <%@ include file="ficheArticleTechnique.jspf" %>
+            </jalios:if>
             <jalios:if predicate="<%= Util.notEmpty(obj.getImagePrincipale()) || obj.getTypeSimple() %>">
                 <%-- Include du gabarit simple --%>
                 <%@ include file="ficheArticleSimple.jspf" %>
@@ -26,7 +30,7 @@
         
         <%-- TODO : bloc "Sur le même thème --%>
         
-        <%-- TEST SGU : portlets bas --%>
+        <%-- Portlets bas --%>
 	    <jalios:if predicate="<%= Util.notEmpty(obj.getBottomportlets()) %>">
 	        <jalios:foreach name="itPortlet" array="<%= obj.getBottomportlets() %>" type="com.jalios.jcms.portlet.PortalElement">
 	           <section>

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleSimple.jspf
@@ -9,9 +9,7 @@
 		class="ds44-contenuArticle">
 		<div class="ds44-inner-container ds44-mtb3">
 	        <div class="ds44-grid12-offset-2">
-				<jalios:if predicate="<%= Util.notEmpty(obj.getTitreParagraphe()) ? 
-						(itCounter <= obj.getTitreParagraphe().length ? Util.notEmpty(obj.getTitreParagraphe()[itCounter - 1]) : false)
-						: false %>">
+				<jalios:if predicate="<%= Util.notEmpty(obj.getTitreParagraphe()) && itCounter <= obj.getTitreParagraphe().length && Util.notEmpty(obj.getTitreParagraphe()[itCounter - 1]) %>">
 					<h2 class="h2-like" id="titreParagraphe<%=itCounter%>"><%=obj.getTitreParagraphe()[itCounter - 1]%></h2>
 				</jalios:if>
 				<jalios:wysiwyg><%=itParagraphe%></jalios:wysiwyg>

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
@@ -1,0 +1,41 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+
+<ds:titleNoBanner title="<%= obj.getTitle(userLang) %>" breadcrumb="true"></ds:titleNoBanner>
+
+<jalios:buffer name="paragraphes">
+    <%-- Boucler sur les paragraphes --%>
+    <jalios:foreach name="itParagraphe" type="String" counter="itCounter"
+        array="<%=obj.getContenuParagraphe()%>">
+        <section id="section<%=itCounter%>" class="ds44-contenuArticle">
+
+                    <jalios:if predicate="<%= Util.notEmpty(obj.getTitreParagraphe()) ? 
+                            (itCounter <= obj.getTitreParagraphe().length ? Util.notEmpty(obj.getTitreParagraphe()[itCounter - 1]) : false)
+                            : false %>">
+                        <h2 class="h2-like" id="titreParagraphe<%=itCounter%>"><%=obj.getTitreParagraphe()[itCounter - 1]%></h2>
+                    </jalios:if>
+                    <jalios:wysiwyg><%=itParagraphe%></jalios:wysiwyg>
+
+        </section>
+    </jalios:foreach>
+</jalios:buffer>
+
+
+
+
+<div class="ds44-inner-container ds44-mt4">
+	<div class="grid-12-small-1">
+	     <div class="col-7">
+	         <%=paragraphes%>
+	</div>
+	<div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
+		<section class="col-4">
+		
+		    <jalios:foreach name="itPortlet" array="<%=obj.getSideportlets()%>" type="com.jalios.jcms.portlet.PortalElement">
+	            <section>
+		            <jalios:include id="<%=itPortlet.getId()%>" />
+	            </section>
+	        </jalios:foreach>
+		
+	    </section>
+	</div>
+</div>

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
@@ -8,9 +8,7 @@
         array="<%=obj.getContenuParagraphe()%>">
         <section id="section<%=itCounter%>" class="ds44-contenuArticle">
 
-                    <jalios:if predicate="<%= Util.notEmpty(obj.getTitreParagraphe()) ? 
-                            (itCounter <= obj.getTitreParagraphe().length ? Util.notEmpty(obj.getTitreParagraphe()[itCounter - 1]) : false)
-                            : false %>">
+                    <jalios:if predicate="<%= Util.notEmpty(obj.getTitreParagraphe()) && itCounter <= obj.getTitreParagraphe().length && Util.notEmpty(obj.getTitreParagraphe()[itCounter - 1]) %>">
                         <h2 class="h2-like" id="titreParagraphe<%=itCounter%>"><%=obj.getTitreParagraphe()[itCounter - 1]%></h2>
                     </jalios:if>
                     <jalios:wysiwyg><%=itParagraphe%></jalios:wysiwyg>
@@ -32,7 +30,7 @@
 		
 		    <jalios:foreach name="itPortlet" array="<%=obj.getSideportlets()%>" type="com.jalios.jcms.portlet.PortalElement">
 	            <section>
-		            <jalios:include id="<%=itPortlet.getId()%>" />
+    				<jalios:include id="<%=itPortlet.getId()%>" />
 	            </section>
 	        </jalios:foreach>
 		


### PR DESCRIPTION
Ajout de champs pour préparer la reprise des "articles géolocalisés"
Ajout d'un champ caché portlets encadrés pour gabarit "technique" (article simple + colonne droite qui sera utilisé pourles formulaires de contacts par exemple).
Le gabarit "technique"