### PR TITLE
Evol : intégration du formulaire de contact

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
@@ -1,0 +1,134 @@
+package fr.cg44.plugin.socle;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+
+import com.jalios.jcms.Channel;
+import com.jalios.jcms.FileDocument;
+import com.jalios.jcms.JcmsUtil;
+import com.jalios.jcms.context.JcmsContext;
+import com.jalios.jcms.mail.MailMessage;
+import com.jalios.util.Util;
+
+import generated.City;
+import generated.ContactForm;
+
+public final class MailUtils {
+	private static Channel channel = Channel.getChannel();
+	
+	private static final Logger LOGGER = Logger.getLogger(MailUtils.class);
+	
+	private MailUtils() {
+		throw new IllegalStateException("Utility class");
+	}
+	
+ /**
+  * Envoi d'un email de contact.
+  */
+ public static void envoiMailContact(ContactForm form, String emailTo) {
+ 		String jsp = "/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp";
+ 	
+   // Objet
+   String objet = channel.getProperty("jcmsplugin.socle.email.sujet.prefix") + " - " + form.getSujet(channel.getDefaultAdmin()).first();
+
+   // Contenu
+   HashMap<Object, Object> parametersMap = new HashMap<Object, Object>();
+   parametersMap.put("nom", form.getNom());
+   parametersMap.put("prenom", form.getPrenom());
+   parametersMap.put("email", form.getMail());
+   parametersMap.put("telephone", form.getTelephone());
+   parametersMap.put("codepostal", form.getCodePostal());
+   parametersMap.put("sujet", form.getSujet(channel.getDefaultAdmin()).first());
+   parametersMap.put("message", form.getMessage());
+   
+   //String content = setContentHtmlFromJsp("/plugins/SoclePlugin/jsp/mail/mailContentTest.jsp", channel.getDefaultAdmin(), "fr", null, null);
+   // Envoi du mail d'activation à l'adresse mail saisie de l'utilisateur
+   try {
+     sendMail(objet, null, form.getMail(), emailTo, null, jsp, parametersMap);
+     msgEnvoiMailContact();
+   } catch (javax.mail.MessagingException e) {
+     msgEchecEnvoiMailContact();
+     LOGGER.error("Erreur lors de l'envoi du mail" + e.getMessage());
+   }
+
+ }
+
+ /**
+  * Envoi de mail avec le pied de mail du CG44.
+  * 
+  * @param subject Objet du mail
+  * @param content Contenu du mail
+  * @param emailFrom Email de l'expéditeur
+  * @param emailTo Email du destinataire
+  * @param listePieceJointe Liste des pièces jointes
+  * @param jsp La JSP du template de mail à envoyer
+  * @param parametersMap La map contenant les données à placer dans le template JSP
+  */
+ public static void sendMail(String subject, String content, String emailFrom, String emailTo, ArrayList<FileDocument> listePieceJointe, String jsp, HashMap<Object, Object> parametersMap)
+     throws javax.mail.MessagingException {
+
+   LOGGER.debug("Envoi du message " + subject);
+   LOGGER.debug("emailFrom = " + emailFrom);
+   LOGGER.debug("emailTo = " + emailTo);
+
+   MailMessage mail = new MailMessage("Département de Loire Atlantique");
+   mail.setFrom(emailFrom);
+   mail.setTo(emailTo);
+   mail.setSubject(subject);
+   
+   if(Util.notEmpty(content)) {
+   	mail.setContentHtml(content);
+   }else if(Util.notEmpty(jsp)) {
+   	mail.setContentHtmlFromJsp(jsp, channel.getDefaultAdmin(), "fr", parametersMap, null);
+   }
+
+   if (Util.notEmpty(listePieceJointe)) {
+     for (FileDocument f : listePieceJointe) {
+       mail.addAttachements(f);
+     }
+   }
+   // Envoi du mail
+   mail.send();
+ }
+ 
+ /**
+  * Envoi du message de confirmation de l'envoi du mail.
+  */
+ public static void msgEnvoiMailContact() {
+   HttpServletRequest request = channel.getCurrentServletRequest();
+   JcmsContext.setInfoMsgSession(JcmsUtil.glpd("jcmsplugin.socle.email.message.succes"), request);
+   LOGGER.debug(JcmsUtil.glpd("jcmsplugin.socle.email.message.succes"));
+ }
+
+ /**
+  * Envoi du message d'erreur d'envoi du mail.
+  */
+ public static void msgEchecEnvoiMailContact() {
+   HttpServletRequest request = channel.getCurrentServletRequest();
+   JcmsContext.setErrorMsgSession(JcmsUtil.glpd("jcmsplugin.socle.email.message.echec"), request);
+   LOGGER.warn(JcmsUtil.glpd("jcmsplugin.socle.email.message.echec"));
+ }  
+ 
+ /**
+  * Ajout des clauses à la fin du message.
+  * 
+  * @param contenu
+  *          le message du mail.
+  * @return le message avec les clauses.
+  */
+ public static String addClause(String contenu) {
+   StringBuilder sb = new StringBuilder(contenu);
+   sb.append("<br />");
+   sb.append("Ce message a &eacute;t&eacute; envoy&eacute; &agrave; partir d'une adresse ne pouvant recevoir d'e-mails. Merci de ne pas y r&eacute;pondre.<br/>");
+   sb.append("<br />");
+   sb.append("---------------------------<br/>");
+   sb.append("<br />");
+   sb.append("En application de la loi n&ordm; 78-17 du 6 janvier 1978 relative &agrave; l'informatique, aux fichiers et aux libert&eacute;s, vous disposez des droits d'opposition, d'acc&egrave;s et de rectification des donn&eacute;es vous concernant. Ainsi, vous pouvez demander une mise &agrave; jour ou une suppression des informations vous concernant si elles s'av&egrave;rent inexactes, incompl&egrave;tes, &eacute;quivoques, p&eacute;rim&eacute;es ou si leur collecte ou leur utilisation, communication ou conservation est interdite.");
+   return sb.toString();
+ } 
+}

--- a/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
@@ -1033,7 +1033,8 @@ public final class SocleUtils {
         } else {
           itNameKey = "longitude";
         }
-      }else if(nameParam.contains("[value]")) {
+      }
+      else if(nameParam.contains("[value]")) {
     	  itNameKey = nameParam.replace("[value]", "");
       }
       // Enregistre les paramètres dans une map dans un format plus classique pour le serveur
@@ -1047,6 +1048,41 @@ public final class SocleUtils {
     }
     return parametersMap;
   }
+  
+  /**
+   * Renvoie les paramètres du formulaire en ajoutant les paramètres nécessaires à JCMS :
+   * Les champs visibles du formulaire sont envoyés via le JS via les paramètres NOMDUCHAMP[text] et NOMDUCHAMP[value]
+   * Les champs cachés sont envoyés avec seulement NOMDUCHAMP[value]
+   * Il faut donc rajouter les champs initiaux NOMDUCHAMP à la requete pour pouvoir être traités par JCMS.
+   * Par ailleurs pour les champs cachés, il n'est pas utile de renvoyer le paramètre NOMDUCHAMP[value]
+   * @param request
+   * @return
+   */
+  public static Map<String, String[]> getFormParameters(HttpServletRequest request) {
+    Enumeration<String> enumParams = request.getParameterNames();
+    Map<String, String[]> parametersMap = new HashMap<String, String[]>();
+    while(enumParams.hasMoreElements()) {
+      String nameParam = enumParams.nextElement();  
+      String itNameKey = null;
+      String itNameKeyText = null;
+      String itNameKeyValue = null;
+      // On ajoute les paramètres nécessaires au JS (paramètres NOMDUCHAMP[text] et NOMDUCHAMP[value])
+      if(nameParam.contains("[text]")){  
+      	itNameKey = nameParam.replaceAll("\\[text\\]","");
+      	itNameKeyText = itNameKey+"[text]";
+      	itNameKeyValue = itNameKey+"[value]";
+      	parametersMap.put(HttpUtil.encodeForURL(itNameKeyText), new String[]{request.getParameter(itNameKeyText)});
+      	parametersMap.put(HttpUtil.encodeForURL(itNameKeyValue), new String[]{request.getParameter(itNameKeyValue)});
+       } 
+      // On ajoute les autres champs du formulaire natif JCMS. On enlève le [value] du nom du champ.
+       else if(nameParam.contains("[value]")) {
+       	itNameKey = nameParam.replace("[value]", "");
+       	parametersMap.put(itNameKey, new String[]{request.getParameter(nameParam)});
+       }
+
+    }
+    return parametersMap;
+  }  
   
   /**
    * Retourne la fonction d'un membre élu, en commençant ou non par une majuscule

--- a/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/ContactFormDataController.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/ContactFormDataController.java
@@ -1,0 +1,146 @@
+package fr.cg44.plugin.socle.datacontroller;
+
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+
+import com.jalios.jcms.BasicDataController;
+import com.jalios.jcms.Category;
+import com.jalios.jcms.Channel;
+import com.jalios.jcms.ControllerStatus;
+import com.jalios.jcms.Data;
+import com.jalios.jcms.JcmsUtil;
+import com.jalios.jcms.Member;
+import com.jalios.jcms.context.JcmsContext;
+import com.jalios.jcms.context.JcmsMessage;
+import com.jalios.jcms.context.JcmsMessage.Level;
+import com.jalios.jcms.plugin.PluginComponent;
+import com.jalios.util.Util;
+
+import fr.cg44.plugin.socle.MailUtils;
+import generated.ContactForm;
+
+public class ContactFormDataController extends BasicDataController implements PluginComponent {
+	private static final Logger LOGGER = Logger.getLogger(ContactFormDataController.class);
+	private static final Channel channel = Channel.getChannel();
+	
+ public ControllerStatus checkIntegrity(Data data) {
+  ControllerStatus status = ControllerStatus.OK;
+  ContactForm form = (ContactForm) data;
+  String userLang = channel.getCurrentUserLang();
+  HttpServletRequest req = channel.getCurrentServletRequest();
+  
+ 	boolean isOK = true;
+
+  // Nom
+  if (Util.isEmpty(form.getNom())) {
+    isOK = false;
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "nom", userLang)));
+  }
+
+  // Prénom
+  if (Util.isEmpty(form.getPrenom())) {
+   isOK = false;
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "prenom", userLang)));
+  }
+
+  // Mail
+  if (Util.isEmpty(form.getMail())) {
+   isOK = false;
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "email", userLang)));
+  }
+  
+  if (Util.notEmpty(form.getMail())) {
+   String regexp = EMAIL_REGEXP;
+   boolean correspond = Pattern.matches(regexp, form.getMail());
+   if (!correspond) {
+    isOK = false;
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "email", userLang)));
+   }
+  } 
+
+  // Code postal
+ 	if(Util.isEmpty(form.getCodePostal())) {
+   isOK = false;
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "codePostal", userLang)));
+ 	}
+ 	
+  if (Util.notEmpty(form.getCodePostal())) {
+   String regexp = channel.getProperty("jcmsplugin.socle.regex.postalcode");
+   boolean correspond = Pattern.matches(regexp, form.getCodePostal());
+   if (!correspond) {
+    isOK = false;
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "codePostal", userLang)));
+   }
+ }  
+  
+  // Téléphone
+ 	if(Util.isEmpty(form.getTelephone())) {
+   isOK = false;
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "telephone", userLang)));
+ 	}
+ 	
+  if (Util.notEmpty(form.getTelephone())) {
+   String regexp = channel.getProperty("jcmsplugin.socle.regex.phone");
+   boolean correspond = Pattern.matches(regexp, form.getTelephone());
+   if (!correspond) {
+    isOK = false;
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "telephone", userLang)));
+   }
+ }
+
+  // Sujet
+  if (Util.isEmpty(form.getSujet(channel.getDefaultAdmin()))) {
+  	isOK = false;
+  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "sujet", userLang)));
+  }
+
+  // Message
+  if (Util.isEmpty(form.getMessage())) {
+  	isOK = false;
+  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "message", userLang)));
+  }
+
+  // Formulaire non valide. On value le titre de la messageBox.
+  if(!isOK) {
+  	status = new ControllerStatus();
+  	req.setAttribute("titreMessageBox",JcmsUtil.glp(userLang, "jcmsplugin.socle.form.invalidfields"));
+  }
+  return status;
+}
+
+
+ public void afterWrite(Data data, int op, Member mbr, @SuppressWarnings("rawtypes") Map context) {
+
+   if (op == OP_CREATE) {
+     ContactForm form = (ContactForm) data;
+
+     // Si la catégorie du sujet a une description, utiliser cette dernière
+     // comme email destinataire
+     // sinon prendre l'email défini dans le module
+     @SuppressWarnings("unchecked")
+     Category sujet = ((TreeSet<Category>) form.getSujet(channel.getDefaultAdmin())).first();
+     String contactMail = Util.notEmpty(sujet.getDescription()) ? sujet.getDescription() : channel.getProperty("jcmsplugin.socle.email.emailParDefaut");
+
+     if (Util.notEmpty(contactMail)) {
+     	contactMail = contactMail.trim();
+       if (Pattern.matches(EMAIL_REGEXP, contactMail)) {
+         LOGGER.debug("Envoi du mail de contact à l'adresse : " + contactMail);
+         MailUtils.envoiMailContact(form, contactMail);
+       } else {
+         LOGGER.error("L'adresse e-mail du destinataire des mails de contact (\"jcmsplugin.socle.email.emailParDefaut\") ne respecte pas le Pattern : "
+             + EMAIL_REGEXP);
+         MailUtils.msgEchecEnvoiMailContact();
+       }
+     } else {
+       LOGGER.error("L'adresse e-mail du destinataire des mails de contact (\"jcmsplugin.socle.email.emailParDefaut\") est vide");
+       MailUtils.msgEchecEnvoiMailContact();
+     }
+   }
+ }
+
+}

--- a/WEB-INF/data/types/ContactForm/ContactForm.xml
+++ b/WEB-INF/data/types/ContactForm/ContactForm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<type name="ContactForm" superclass="com.jalios.jcms.Form" formOneSubmit="false" formNotify="false" formAuthor="j_2" formRedirectMode="currentCategory" categoryTab="true" readRightTab="true" updateRightTab="true" templateTab="true" workflowTab="true" advancedTab="true" titleML="true" hbm="true" debatable="false" unitFieldEdition="true" audienced="false" categories="" authgroups="||" database="true">
+  <title ml="false">
+    <label xml:lang="fr">Titre</label>
+    <label xml:lang="en">Title</label>
+  </title>
+  <fields>
+    <field name="nom" editor="textfield" required="false" type="String" searchable="true" size="80" compactDisplay="false" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Nom</label>
+      <label xml:lang="en">Name</label>
+    </field>
+    <field name="prenom" editor="textfield" required="false" type="String" searchable="true" size="80" compactDisplay="false" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Prénom</label>
+    </field>
+    <field name="mail" editor="email" required="false" compactDisplay="false" type="String" searchable="false" size="50" maxlength="500" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Courriel</label>
+    </field>
+    <field name="codePostal" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="5" ml="false" html="false" checkHtml="false" descriptionType="text" maxlength="5">
+      <label xml:lang="fr">Code postal</label>
+    </field>
+    <field name="telephone" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Téléphone</label>
+    </field>
+    <field name="sujet" editor="category" required="false" compactDisplay="false" type="java.util.TreeSet" chooser="listbox" exclusive="true" root="$jcmsplugin.socle.form.contactform.sujet.root" ml="false" descriptionType="text" searchable="false" html="false" checkHtml="true" displayRoot="false">
+      <label xml:lang="fr">Sujet</label>
+    </field>
+    <field name="message" editor="textarea" required="false" compactDisplay="false" type="String" searchable="false" rows="5" cols="80" ml="false" wiki="false" wikiwyg="false" html="false" checkHtml="false" descriptionType="tooltip">
+      <label xml:lang="fr">Votre message</label>
+    </field>
+  </fields>
+  <label xml:lang="fr">Formulaire de contact</label>
+</type>
+

--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -20,7 +20,7 @@
     <type name="CollectivityArticle"></type>
     <type name="CommuneHorsDepartement"></type>
     <type name="Contact"></type>
-    <type name="ContenuDeTest"></type>
+    <type name="ContactForm"><file path="editFormContactForm.jsp" /></type>
     <type name="ContenuPush"></type>
     <type name="CultureProfessionalCard"></type>
     <type name="Delegation"></type>
@@ -68,6 +68,7 @@
     <type name="SeniorCitizensEstablishment"></type>
     <type name="Temoignage"></type>
     <type name="Video"></type>
+
     
     
     <!-- Types de contenus -->    
@@ -166,6 +167,9 @@
     <templates type="FileDocument">
         <template name="embed" file="doFileDocumentEmbedDisplay.jsp" usage="embed">
             <label xml:lang="fr">Gabarit imbriqué pour affichage dans un autre contenu</label>
+        </template>
+        <template name="default" file="doFileDocumentFullDisplay.jsp" usage="full">
+            <label xml:lang="fr">Gabarit full pour la refonte</label>
         </template>
     </templates>
     <templates type="News">
@@ -386,7 +390,7 @@
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FicheArticleDataController" types="FicheArticle" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.IndexationDataController" types="Publication" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FichePublicationDataController" types="FichePublication" />
-    <!--<datacontroller  class="fr.cg44.plugin.socle.datacontroller.ContactFormDataController" types="ContactForm" />-->
+    <datacontroller  class="fr.cg44.plugin.socle.datacontroller.ContactFormDataController" types="ContactForm" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.SoclePortalPolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCityEnginePolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCantonEnginePolicyFilter" />
@@ -432,6 +436,7 @@
     <file path="WEB-INF/tags/facetteCategorieListElem.tag" />
     <file path="WEB-INF/tags/figurePicture.tag" />
     <file path="WEB-INF/tags/levelTwoMenu.tag" />
+    <file path="WEB-INF/tags/message.tag" />
     <file path="WEB-INF/tags/menuLink.tag" />
     <file path="WEB-INF/tags/pdcvSearchFields.tag" />
     <file path="WEB-INF/tags/phone.tag" />

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -38,6 +38,21 @@ jcmsplugin.socle.rgpd.pub.id: RGPD : ID de la page RGPD
 $jcmsplugin.socle.recherche.facettes.portal: ID du Portail de la recherche à facettes
 
 # ------------------------------------------------------------
+#  Formulaires
+# ------------------------------------------------------------
+jcmsplugin.socle.form.invalidfields: Ces champs ne sont pas valides, merci de les vérifier :
+jcmsplugin.socle.form.exemple.email: Exemple : monadresse@mail.com
+jcmsplugin.socle.form.exemple.tel: Exemple : 0202030405
+jcmsplugin.socle.form.exemple.codepostal: Exemple : 44000
+
+# ------------------------------------------------------------
+#  Mail
+# ------------------------------------------------------------
+jcmsplugin.socle.email.message.succes : Merci, votre message a été envoyé.
+jcmsplugin.socle.email.message.echec : Une erreur s'est produite lors de l'envoi de l'email.
+
+
+# ------------------------------------------------------------
 #  Sectorisation
 # ------------------------------------------------------------
 jcmsplugin.socle.sectorisation.commune.url: Url de la sectorisation par commune

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -273,6 +273,8 @@ jcmsplugin.socle.site.pdcv.portlet.id:
 #  Formulaires
 # ------------------------------------------------------------
 $jcmsplugin.socle.form.contactform.sujet.root: aca_8167
+jcmsplugin.socle.email.emailParDefaut: contact@loire-atlantique.fr
+jcmsplugin.socle.email.sujet.prefix: Loire-Atlantique.fr
 
 # ------------------------------------------------------------
 #  Catégories racines des types de contenu

--- a/WEB-INF/tags/message.tag
+++ b/WEB-INF/tags/message.tag
@@ -1,0 +1,70 @@
+<%@tag import="com.jalios.jcms.context.JcmsContext"%>
+<%@tag import="com.jalios.util.Browser"%>
+<%@tag import="com.jalios.jcms.JcmsUtil"%>
+<%@ taglib uri="jcms.tld" prefix="jalios" %>
+<%@ tag 
+    pageEncoding="UTF-8"
+    description="Génère une boîte d'affichage de message." 
+    body-content="tagdependent" 
+    import="com.jalios.jcms.Channel,
+            com.jalios.util.ServletUtil,
+            com.jalios.jcms.JcmsUtil,
+            com.jalios.util.Util,
+            com.jalios.jcms.context.JcmsMessage,
+            java.util.List"
+%>
+<%@ attribute name="msg"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le message à afficher"
+%>
+<%@ attribute name="msgList"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="List<JcmsMessage>"
+    description="La liste des messages à afficher"
+%>
+<%@ attribute name="title"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Le titre de la boîte"
+%>
+<%@ attribute name="css"
+    required="false"
+    fragment="false"
+    rtexprvalue="true"
+    type="String"
+    description="Les styles à appliquer"
+%>
+<%
+String uid = ServletUtil.generateUniqueDOMId(request, "uid");
+String userLang = Channel.getChannel().getCurrentJcmsContext().getUserLang();
+%>
+
+<div class="ds44-errorMsg-container" aria-live="polite">
+    <jalios:if predicate='<%= Util.notEmpty(title) %>'>
+        <p id="error-mgs" class="ds44-msgErrorText ds44-msgErrorInvalid" tabindex="-1">
+            <i class="icon icon-attention icon--sizeM" aria-hidden="true"></i>
+            <span class="ds44-iconInnerText ds44-errorLabel"><%= title %></span>
+        </p>
+    </jalios:if>
+        
+	<jalios:select>
+		<jalios:if predicate='<%= Util.notEmpty(msg) %>'>
+		  <%= msg %>
+		</jalios:if>
+		<jalios:if predicate='<%= Util.notEmpty(msgList) %>'>
+			<ul class="ds44-errorList">
+                <jalios:foreach name="itMessage" type="JcmsMessage" collection="<%= msgList %>">
+                    <li><%= JcmsUtil.glp(userLang,itMessage.getMessage()) %></li>
+			     </jalios:foreach>
+			</ul>
+		</jalios:if>
+	</jalios:select>
+        
+</div>

--- a/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf
+++ b/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf
@@ -1,0 +1,120 @@
+<%--
+DEP44 : Recopie et adaptation du fichier natif /jcore/doMessageBox.jspf
+pour pouvoir s'adapter aux contraintes graphiques du DS
+--%>
+<%@page import="com.jalios.util.Util"%><%
+%><%@page import="com.jalios.jcms.JcmsConstants"%><%
+%><%@page import="com.jalios.jcms.context.JcmsContext"%><%
+%><%@page import="com.jalios.jcms.context.JcmsMessage"%><%
+%><%@page import="com.jalios.jcms.context.MessageLevel"%><%
+%><%@page import="java.util.List"%><%
+%><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
+{
+  String titreMessageBox = Util.getString(request.getAttribute("titreMessageBox"), "");
+	
+  String sessionErrorMsg = Util.getString(request.getSession().getAttribute(JcmsConstants.ERROR_MSG), "");
+  String sessionWarningMsg = Util.getString(request.getSession().getAttribute(JcmsConstants.WARNING_MSG), "");
+  String sessionInfoMsg = Util.getString(request.getSession().getAttribute(JcmsConstants.INFORMATION_MSG), "");
+  String sessionSuccessMsg = Util.getString(request.getSession().getAttribute(JcmsConstants.SUCCESS_MSG), "");
+
+  String requestErrorMsg = Util.getString(request.getAttribute(JcmsConstants.ERROR_MSG), "");
+  String requestWarningMsg = Util.getString(request.getAttribute(JcmsConstants.WARNING_MSG), "");
+  String requestInfoMsg = Util.getString(request.getAttribute(JcmsConstants.INFORMATION_MSG), "");
+  String requestSuccessMsg = Util.getString(request.getAttribute(JcmsConstants.SUCCESS_MSG), "");
+
+  String pageContextErrorMsg = Util.getString(pageContext.getAttribute(JcmsConstants.ERROR_MSG), "");
+  String pageContextWarningMsg = Util.getString(pageContext.getAttribute(JcmsConstants.WARNING_MSG), "");
+  String pageContextInfoMsg = Util.getString(pageContext.getAttribute(JcmsConstants.INFORMATION_MSG), "");
+  String pageContextSuccessMsg = Util.getString(pageContext.getAttribute(JcmsConstants.SUCCESS_MSG), "");
+
+  String tag = "p";
+  
+  String errorMsg = Util.surroundWithTag(glp(sessionErrorMsg), tag);
+  String warningMsg = Util.surroundWithTag(glp(sessionWarningMsg), tag);
+  String infoMsg = Util.surroundWithTag(glp(sessionInfoMsg), tag);
+  String successMsg = Util.surroundWithTag(glp(sessionSuccessMsg), tag);
+
+  errorMsg += Util.surroundWithTag(glp(requestErrorMsg), tag);
+  warningMsg += Util.surroundWithTag(glp(requestWarningMsg), tag);
+  infoMsg += Util.surroundWithTag(glp(requestInfoMsg), tag);
+  successMsg += Util.surroundWithTag(glp(requestSuccessMsg), tag);
+
+  errorMsg += Util.surroundWithTag(glp(pageContextErrorMsg), tag);
+  warningMsg += Util.surroundWithTag(glp(pageContextWarningMsg), tag);
+  infoMsg += Util.surroundWithTag(glp(pageContextInfoMsg), tag);
+  successMsg += Util.surroundWithTag(glp(pageContextSuccessMsg), tag);
+
+  List<JcmsMessage> errorsList = JcmsContext.getErrorMsgList(request);
+  List<JcmsMessage> warningList = JcmsContext.getWarningMsgList(request);
+  List<JcmsMessage> infoList = JcmsContext.getInfoMsgList(request);
+  List<JcmsMessage> successList = JcmsContext.getSuccessMsgList(request);
+
+  if (errorsList == null) {
+    errorsList = JcmsContext.getErrorMsgSessionList(request);
+  } else {     
+    List<JcmsMessage> errorSessionList = JcmsContext.getErrorMsgSessionList(request);
+    if(errorSessionList != null) {
+      errorsList.addAll(errorSessionList);
+    }
+  }
+  if (warningList == null) {
+    warningList = JcmsContext.getWarningMsgSessionList(request);
+  } else {
+    List<JcmsMessage> warningSessionList = JcmsContext.getWarningMsgSessionList(request);
+    if(warningSessionList != null) {
+      warningList.addAll(warningSessionList);
+    }
+  }
+  if (infoList == null) {
+    infoList = JcmsContext.getInfoMsgSessionList(request);
+  } else {      
+    List<JcmsMessage> infoSessionList = JcmsContext.getInfoMsgSessionList(request);
+    if(infoSessionList != null) {
+      infoList.addAll(infoSessionList);
+    }
+  }
+  if (successList == null) {
+    successList = JcmsContext.getSuccessMsgSessionList(request);
+  } else {      
+    List<JcmsMessage> successSessionList = JcmsContext.getSuccessMsgSessionList(request);
+    if(successSessionList != null) {
+      successList.addAll(successSessionList);
+    }
+  }
+  
+  if (Util.notEmpty(errorMsg)) {
+    %><ds:message msg="<%= errorMsg %>" msgList="" title="<%= titreMessageBox %>" css="ds44-errorMsg-container"/><%
+  }
+  if (Util.notEmpty(warningMsg)) {
+    %><ds:message msg="<%= warningMsg %>" msgList="" title="<%= titreMessageBox %>" css="ds44-errorMsg-container"/><%
+  }
+  if (Util.notEmpty(infoMsg)) {
+    %><ds:message msg="<%= infoMsg %>" msgList="" title="<%= titreMessageBox %>" css=""/><%
+  }
+  if (Util.notEmpty(successMsg)) {
+    %><ds:message msg="<%= successMsg %>" msgList="" title="<%= titreMessageBox %>" css=""/><%
+  }
+  
+  if (Util.notEmpty(errorsList)) {
+    %><ds:message msg="" msgList="<%= errorsList %>" title="<%= titreMessageBox %>" css="ds44-errorMsg-container"/><%
+  } 
+  if (Util.notEmpty(warningList)) {%>
+    <ds:message msg="" msgList="<%= warningList %>" title="<%= titreMessageBox %>" css="ds44-errorMsg-container"/><%
+  }
+  if (Util.notEmpty(infoList)) {
+    %><ds:message msg="" msgList="<%= infoList %>" title="<%= titreMessageBox %>" css=""/><%
+  }
+  if (Util.notEmpty(successList)) {
+    %><ds:message msg="" msgList="<%= successList %>" title="<%= titreMessageBox %>" css=""/><%
+  }
+  request.getSession().removeAttribute(JcmsConstants.ERROR_MSG);
+  request.getSession().removeAttribute(JcmsConstants.WARNING_MSG);
+  request.getSession().removeAttribute(JcmsConstants.INFORMATION_MSG);
+  request.getSession().removeAttribute(JcmsConstants.SUCCESS_MSG);
+    
+  JcmsContext.removeMessage(request, errorsList);
+  JcmsContext.removeMessage(request, warningList);
+  JcmsContext.removeMessage(request, infoList);
+  JcmsContext.removeMessage(request, successList);
+}
+%>

--- a/plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp
+++ b/plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp
@@ -1,0 +1,15 @@
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@page import="fr.cg44.plugin.socle.SocleUtils"%><%
+%><%@ include file='/jcore/doInitPage.jspf' %><%
+
+Map<String, String[]> parametersMap = SocleUtils.getFormParameters(request);
+
+String redirectUrl = request.getParameter("redirect[value]");
+
+String url = URLUtils.buildUrl(redirectUrl, parametersMap);
+
+sendRedirect(url);
+
+%>
+
+

--- a/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf
+++ b/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf
@@ -1,0 +1,13 @@
+<%@ page contentType="text/html; charset=UTF-8"%>
+
+    <p class="ds44-wsg-smallText ds44-mt3"><%= channel.getProperty("jcmsplugin.socle.rgpd.form.text") %>
+		<jalios:if predicate='<%= Util.notEmpty(channel.getProperty("jcmsplugin.socle.rgpd.pub.id")) && Util.notEmpty(channel.getProperty("jcmsplugin.socle.rgpd.form.text")) %>'>
+		    <jalios:link id='<%= channel.getProperty("jcmsplugin.socle.rgpd.pub.id") %>'><%= channel.getProperty("jcmsplugin.socle.rgpd.form.text") %></jalios:link>
+		</jalios:if>
+    </p>
+  </div>
+</div>
+
+<% } %>
+
+

--- a/plugins/SoclePlugin/jsp/forms/doFormHeader.jspf
+++ b/plugins/SoclePlugin/jsp/forms/doFormHeader.jspf
@@ -1,0 +1,10 @@
+<%@ page contentType="text/html; charset=UTF-8"%>
+<% if(channel.isDataWriteEnabled()) { %>
+
+<div class="ds44-box ds44-theme mbm">
+    <div class="ds44-innerBoxContainer">
+        <p class="ds44-box-heading ds44-mb-std" role="heading" aria-level="2">Formulaire de contact</p>
+        <p>Les champs suivis d’un * sont obligatoires.</p>
+
+
+

--- a/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp
@@ -1,0 +1,343 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Newsletter numéro #1</title>
+  <style type="text/css">
+    /* Based on The MailChimp Reset INLINE: Yes. */
+    /* Client-specific Styles */
+    #outlook a {
+      padding: 0;
+    }
+
+    /* Force Outlook to provide a "view in browser" menu link. */
+    body {
+      font-family: Arial, Verdana, Geneva, sans-serif;
+      width: 100% !important;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    /* Prevent Webkit and Windows Mobile platforms from changing default font sizes.*/
+    .ExternalClass {
+      width: 100%;
+    }
+
+    /* Force Hotmail to display emails at full width */
+    .ExternalClass,
+    .ExternalClass p,
+    .ExternalClass span,
+    .ExternalClass font,
+    .ExternalClass td,
+    .ExternalClass div {
+      line-height: 100%;
+    }
+
+    /* Forces Hotmail to display normal line spacing.  More on that: http://www.emailonacid.com/forum/viewthread/43/ */
+    #backgroundTable {
+      margin: 0;
+      padding: 0;
+      width: 100% !important;
+      line-height: 100% !important;
+    }
+
+    /* End reset */
+
+    /* Some sensible defaults for images
+Bring inline: Yes. */
+    img {
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+      width: 100%;
+    }
+
+    a img {
+      border: none;
+    }
+
+    /* Yahoo paragraph fix
+Bring inline: Yes. */
+    p {
+      margin: 1em 0;
+    }
+
+    /* Hotmail header color reset
+Bring inline: Yes. */
+     h1,
+     h2,
+     h3,
+     h4,
+     h5,
+     h6 {
+      color: #000000 !important;
+      text-align: left;
+    }
+
+    h1 {
+      font-size: 36px;
+      line-height:43px;
+    }
+
+    h2 {
+      font-size: 24px;
+    }
+
+    h3 {
+      font-size: 20px;
+    }
+
+    h4, h5, h6 {
+      font-size: 17px;
+    }
+
+     h1 a,
+     h2 a,
+     h3 a,
+     h4 a,
+     h5 a,
+     h6 a {
+      color: #000000 !important;
+      text-decoration: none;
+    }
+
+     h1 a:hover,
+     h2 a:hover,
+     h3 a:hover,
+     h4 a:hover,
+     h5 a:hover,
+     h6 a:hover {
+      text-decoration: underline;
+    }
+
+    /* Outlook 07, 10 Padding issue fix
+Bring inline: No.*/
+    table td {
+      border-collapse: collapse;
+    }
+
+    /* Remove spacing around Outlook 07, 10 tables
+Bring inline: Yes */
+    table {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    .vTop {
+        vertical-align: top;
+    }
+
+    /* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email and make sure to bring your styles inline.  Your link colors will be uniform across clients when brought inline.
+Bring inline: Yes. */
+    a {
+      color: #000000;
+      text-decoration: underline;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
+
+    a:hover,
+    a:active,
+    a:focus,
+    a:visited {
+      color: #000000 !important;
+    }
+
+    ul.list > li {
+        list-style-position: outside;
+        margin-bottom:10px;
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/right.svg");
+    }
+
+    ul.list > li ul > li {
+        list-style-type: disc;
+        list-style-image: unset;
+    }
+
+    ul.list li.icon-mail {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/cd44-mail-black.svg");
+    }
+
+    ul.list li.icon-tel {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/cd44-phone-black.svg");
+    }
+
+    ul.list li.icon-location {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/cd44-marker-black.svg");
+    }
+
+    ul.list li.icon-date {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/cd44-date-black.svg");
+    }
+
+    ul.list li.icon-link {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/cd44-link-black.svg");
+    }
+
+    ul.list li.icon-puce {
+        list-style-image: url("https://dev-design.loire-atlantique.fr/assets/images/newsletter/right.svg");
+    }
+
+    ul.list.noMrg {
+        padding-left: 30px !important;
+    }
+
+    .noMrg,
+    ul p {
+        margin:0 !important;
+    }
+
+    .col-left,
+    .col-right {
+        width:50%;
+        vertical-align: top;
+    }
+
+    .col-left {
+        padding-right:15px;
+    }
+
+    .col-right {
+        padding-left:15px;
+    }
+
+    .ds44-introduction {
+      font-size: 19px;
+      font-weight: 700;
+      margin-top: 0;
+      margin-bottom: 2rem;
+      line-height: 27px;
+  }
+
+
+    /***************************************************
+****************************************************
+MOBILE TARGETING
+****************************************************
+***************************************************/
+
+    @media only screen and (max-width: 639px) {
+      TABLE.content {
+        width: 240px !important;
+      }
+
+      P,
+      DIV,
+      LI,
+      UL,
+      span {
+        font-size: 14px;
+      }
+
+      h1 {
+        font-size: 30px;
+        line-height:38px;
+      }
+
+      h2 {
+        font-size: 20px;
+      }
+
+      h3 {
+        font-size: 18px;
+      }
+
+      h4, h5, h6 {
+        font-size: 16px;
+      }
+
+
+      .thumbnail IMG {
+        display: block;
+      }
+
+      .col-left,
+      .col-right {
+          width:100%;
+          padding:0;
+          display: block;
+      }
+
+      .col-right {
+          margin-top: 20px;
+          text-align: center;
+      }
+
+      .ds44-introduction {
+        font-size: 16px;
+        line-height: 23px;
+    }
+
+
+}
+
+  </style>
+</head>
+
+<body>
+  <style media="all" type="text/css">
+    td {
+      font-family: Arial, Verdana, Geneva, sans-serif;
+      font-size: 16px;
+    }
+  </style>
+  <!-- Wrapper/Container Table: Use a wrapper table to control the width and the background color consistently of your email. Use this approach instead of setting attributes on the body tag. -->
+  <table id="backgroundTable" style="font-size: 16px; background-color: #FFFFFF; margin: 0 auto; line-height:150%;width:800px;max-width:800px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;" width="100%" cellspacing="0" cellpadding="0">
+    <tbody>
+      <tr>
+        <td class="vTop">
+          <!-- Tables are the most common way to format your email consistently. Set your table widths inside cells and in most cases reset cellpadding, cellspacing, and border to zero. Use nested tables as a way to space effectively in your message. -->
+
+          <table class="content" style="line-height:150%;width:600px;max-width:600px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;margin:0 auto;" width="600" cellspacing="0" cellpadding="0" align="center">
+            <tbody>
+                <tr>
+                  <th>
+                    <table style="margin: 15px 0 ; color: #000000;">
+                      <tbody>
+                        <tr>
+                          <td>
+                              <a href="#">
+                                  <img src="https://dev-design.loire-atlantique.fr/assets/images/newsletter/logo-loire-atlantique-information.svg" style="height=62px;" alt="image" class="" />
+                              </a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </th>
+                </tr>
+              <tr>
+                <td style="background: #fff; color: #000000;" class="vTop">
+                  <table class="mail-body" width="100%" cellpadding="0" style="margin:30px 0;">
+                    <tbody>
+                      <tr>
+                        <td>
+                        <p>Nom : <%=request.getAttribute("nom") %></p>
+                        <p>Prénom : <%=request.getAttribute("prenom") %></p>
+                        <p>Email : <%=request.getAttribute("email") %></p>
+                        <p>Téléphone : <%=request.getAttribute("telephone") %></p>
+                        <p>Code postal : <%=request.getAttribute("codepostal") %></p>
+                        <p>Sujet : <%=request.getAttribute("sujet") %></p>
+                        <p>Message : <%=request.getAttribute("message") %></p>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+
+    </tbody>
+  </table>
+
+</body>
+
+</html>
+
+
+

--- a/plugins/SoclePlugin/types/ContactForm/doEditContactForm.jsp
+++ b/plugins/SoclePlugin/types/ContactForm/doEditContactForm.jsp
@@ -1,0 +1,187 @@
+<%-- This file has been automatically generated. --%>
+<%--
+  @Summary: ContactForm content editor
+  @Category: Generated
+  @Author: JCMS Type Processor 
+  @Customizable: True
+  @Requestable: False 
+--%>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ include file='/jcore/doInitPage.jspf' %>
+<% 
+  EditContactFormHandler formHandler = (EditContactFormHandler)request.getAttribute("formHandler");
+  ServletUtil.backupAttribute(pageContext, "classBeingProcessed");
+  request.setAttribute("classBeingProcessed", generated.ContactForm.class);
+%>
+<%-- Name ------------------------------------------------------------ --%>
+<% String nomLabel = channel.getTypeFieldLabel(ContactForm.class, "nom", userLang);%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-nom" class="ds44-formLabel">
+              <span class="ds44-labelTypePlaceholder"><span><%= nomLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-nom" name="nom"
+                class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", nomLabel) %>"
+                required="" autocomplete="family-name">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", nomLabel) %></span>
+            </button>
+        </div>
+    </div>
+</div>
+ 
+<%-- FirstName ------------------------------------------------------------ --%>
+<% String prenomLabel = channel.getTypeFieldLabel(ContactForm.class, "prenom", userLang);%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-prenom" class="ds44-formLabel">
+              <span class="ds44-labelTypePlaceholder"><span><%= prenomLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-prenom" name="prenom" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", prenomLabel) %>"
+                required="" autocomplete="given-name">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", prenomLabel) %></span>
+            </button>
+        </div>
+    </div>
+</div>
+ 
+<%-- Mail ------------------------------------------------------------ --%>
+<% String mailLabel = channel.getTypeFieldLabel(ContactForm.class, "mail", userLang);%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-mail" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= mailLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="email" id="form-element-mail" name="mail" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", mailLabel) %>"
+                required="" autocomplete="email" aria-describedby="explanation-form-element-mail"
+                data-bkp-aria-describedby="explanation-form-element-mail">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", mailLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-mail" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.email") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<%-- Phone ------------------------------------------------------------ --%>
+<% String telephoneLabel = channel.getTypeFieldLabel(ContactForm.class, "telephone", userLang);%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-telephone" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= telephoneLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-telephone" name="telephone" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", telephoneLabel) %>"
+                autocomplete="tel" aria-describedby="explanation-form-element-telephone"
+                data-bkp-aria-describedby="explanation-form-element-telephone">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", telephoneLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-telephone" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.tel") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+ 
+<%-- CodePostal ------------------------------------------------------------ --%>
+<% String codepostalLabel = channel.getTypeFieldLabel(ContactForm.class, "codePostal", userLang);%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-codepostal" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= codepostalLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-codepostal" name="codePostal" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", codepostalLabel) %>"
+                autocomplete="postal-code" aria-describedby="explanation-form-element-codepostal"
+                data-bkp-aria-describedby="explanation-form-element-codepostal">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", codepostalLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-codepostal" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.codepostal") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<%-- Sujet ------------------------------------------------------------ --%>
+<% String sujetLabel = channel.getTypeFieldLabel(ContactForm.class, "sujet", userLang);%>
+<%
+TreeSet sujetCatSet = new TreeSet(Category.getOrderComparator(userLang));
+sujetCatSet.addAll(formHandler.getSujetRoot().getChildrenSet());
+%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+		<div class="ds44-select__shape ds44-inpStd">
+		    <p class="ds44-selectLabel" aria-hidden="true"><%= sujetLabel %><sup aria-hidden="true">*</sup></p>
+		    <input class="ds44-input-value" type="hidden"><div id="sujet" data-name="sujet" class="ds44-js-select-radio ds44-selectDisplay" data-required="true"></div>
+		    <button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", sujetLabel) %></span></button>
+		    <button type="button" id="button-form-element-sujet" class="ds44-btnIco ds44-posAbs ds44-posRi ds44-btnOpen" aria-expanded="false" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", sujetLabel) %>"><i class="icon icon--sizeL icon-down" aria-hidden="true"></i><span id="button-message-form-element-sujet" class="visually-hidden"><%= sujetLabel %></span></button>
+		</div>
+
+	    <div class="ds44-select-container hidden" data-bkp-aria-hidden="" aria-hidden="true">
+	        <div class="ds44-listSelect">
+	            <ul class="ds44-list" id="listbox-form-element-sujet">
+	               <jalios:foreach name="itCat" type="Category" collection="<%= sujetCatSet %>">
+	                   <li class="ds44-select-list_elem selected_option">
+						<div class="ds44-form__container ds44-checkBox-radio_list ">
+						    <input type="radio" name="sujet" value="<%= itCat.getId() %>" id="form-element-sujet-<%= itCounter %>" class="ds44-radio" data-bkp-tabindex="" tabindex="-1"><label id="label-form-element-sujet-<%= itCounter %>" for="form-element-sujet-<%= itCounter %>" class="ds44-radioLabel"><%= itCat.getName() %></label>
+						</div>
+                        </li>
+	                </jalios:foreach>
+	            </ul>
+	        </div>
+	        <button type="button" class="ds44-fullWBtn ds44-btnSelect ds44-theme" title="<%= glp("jcmsplugin.socle.facette.cat-lie.valider-selection.label", sujetLabel) %>" data-bkp-tabindex="" tabindex="-1"><span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.valider") %></span><i class="icon icon-long-arrow-right ds44-noLineH" aria-hidden="true"></i></button>
+	    </div>
+    </div>
+</div>
+ 
+<%-- Message ------------------------------------------------------------ --%>
+<% String messageLabel = channel.getTypeFieldLabel(ContactForm.class, "message", userLang);%>
+<div class="ds44-mb3">
+	<div class="ds44-form__container">
+		<div class="ds44-posRel">
+            <label for="form-element-message" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= messageLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+			<textarea rows="5" cols="1" id="form-element-message" name="message" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", messageLabel) %>" required=""></textarea>
+		</div>
+	</div>
+</div>
+
+
+
+<button
+    class="jcms-js-submit ds44-btnStd ds44-btn--invert ds44-bntFullw ds44-bntALeft"
+    title="Valider l'envoi de votre demande">
+    <span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.valider") %></span><i
+        class="icon icon-long-arrow-right" aria-hidden="true"></i>
+</button>
+
+
+
+ 
+<%
+{ 
+ TreeSet  removedCatSet = new TreeSet(); 
+ Category itRemoveCat = null;
+ itRemoveCat = channel.getCategory("$jcmsplugin.socle.form.contactform.sujet.root");
+ if (itRemoveCat != null){ removedCatSet.add(itRemoveCat);  }
+ request.setAttribute("ContactForm.removedCatSet", removedCatSet);
+}   
+%>
+<jalios:include target="EDIT_PUB_MAINTAB" targetContext="div" />
+<jalios:include jsp="/jcore/doEditExtraData.jsp" />

--- a/plugins/SoclePlugin/types/ContactForm/editFormContactForm.jsp
+++ b/plugins/SoclePlugin/types/ContactForm/editFormContactForm.jsp
@@ -1,0 +1,54 @@
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@ include file='/jcore/doInitPage.jspf' %><%
+%><% String[] formTitles = JcmsUtil.getLanguageArray(channel.getTypeEntry(ContactForm.class).getLabelMap()); %>
+<jsp:useBean id='formHandler' scope='page' class='generated.EditContactFormHandler'>
+  <jsp:setProperty name='formHandler' property='request' value='<%= request %>'/>
+  <jsp:setProperty name='formHandler' property='response' value='<%= response %>'/>
+  <jsp:setProperty name='formHandler' property='*' />
+  <jsp:setProperty name='formHandler' property='author' value='j_2'/>
+  <jsp:setProperty name='formHandler' property='title' value='<%= formTitles %>'/>
+</jsp:useBean>
+<%
+  if (formHandler.validate()) {
+    return;
+  }
+
+%>   
+
+<jalios:if predicate='<%= formHandler.isOneSubmit() && formHandler.isSubmitted() %>'>
+  <% setWarningMsg(glp("msg.edit.already-one-submit"), request); %>
+</jalios:if>
+
+
+<%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
+
+
+<%@ include file='/plugins/SoclePlugin/jsp/forms/doFormHeader.jspf' %>
+
+    <%-- -- FORM -------------------------------------------- --%>
+    <jalios:query name='__memberSet' dataset='<%= channel.getDataSet(Member.class) %>' comparator='<%= Member.getNameComparator() %>'/>
+    <% request.setAttribute("formMemberSet", __memberSet); %>
+    <jalios:query name='__groupSet' dataset='<%= channel.getDataSet(Group.class) %>' comparator='<%= Group.getNameComparator() %>'/>
+    <% request.setAttribute("formGroupSet", __groupSet); %>
+    
+    <%
+    String formAction = "plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp";
+    Publication currentPub = (Publication) request.getAttribute(PortalManager.PORTAL_PUBLICATION);
+    %>
+    <form action='<%= formAction %>' method='post' name='editForm' accept-charset="UTF-8"  enctype="multipart/form-data">
+        
+        <% request.setAttribute("formHandler", formHandler); %>
+
+        <jsp:include page="doEditContactForm.jsp" />
+        
+        <input type='hidden' name='redirect' value='<%= currentPub.getDisplayUrl(userLocale) %>' data-technical-field />
+        <input type='hidden' name='ws' value='<%= formHandler.getWorkspace().getId() %>' data-technical-field />
+        <input type='hidden' name='opCreate' value='<%= glp("ui.com.btn.submit") %>' data-technical-field />
+        <input type="hidden" name="csrftoken" value="<%= HttpUtil.getCSRFToken(request) %>" data-technical-field>
+        <input type="hidden" name="noSendRedirect" value='true' data-technical-field />
+        <input type="hidden" name="id" value='<%= request.getParameter("id") %>' data-technical-field />
+    
+    </form>
+
+<%@ include file='/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf' %>
+


### PR DESCRIPTION
- Déclaration du type de formulaire
- Gabarits de saisie personnalisés
- Copie de doMessageBox.jspf pour adapter au DS
- Ajout d'un tag pour gestion des messages succes/erreur pour remplacer le natif <jalios:message>
- Datacontroller pour vérifier saisie + envoi de mail
- Ajout d'une méthode dans SocleUtils pour parser et transmettre les paramètres du formulaire.
- Ajout de classe utilitaire d'envoi de mail