### PR TITLE
Evol page carrefour SEO

### DIFF
--- a/WEB-INF/data/types/PageCarrefour/PageCarrefour.xml
+++ b/WEB-INF/data/types/PageCarrefour/PageCarrefour.xml
@@ -5,6 +5,10 @@
     <label xml:lang="en">Title</label>
   </title>
   <fields>
+    <field name="titreUrl" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="true">
+      <label xml:lang="fr">Titre URL</label>
+      <description xml:lang="fr">&lt;div class="wysiwyg"&gt;&lt;p&gt;Si rempli, apparaitra dans l'URL à la place du titre.&lt;/p&gt;&lt;/div&gt;</description>
+    </field>  
     <field name="imageBandeau" editor="image" required="true" compactDisplay="false" type="String" searchable="false" size="80" ml="false" descriptionType="text" dataimage="true" html="false" checkHtml="true">
       <label xml:lang="fr">Image bandeau</label>
       <description xml:lang="fr">&lt;div class="wysiwyg"&gt;&lt;p&gt;Format attendu : 1240x460px&lt;/p&gt;&lt;/div&gt;</description>


### PR DESCRIPTION
Ajout d'un champ "titre URL" pour mettre dans l'URL à la place du champ "titre".
Champ pris en compte par le module SEO