### PR TITLE
Fix : gestion du logo du header

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -64,6 +64,7 @@ jcmsplugin.socle.rgpd.pub.id:
 # ------------------------------------------------------------
 jcmsplugin.socle.site.src.logo: https://design.loire-atlantique.fr/assets/images/logo-loire-atlantique.svg
 jcmsplugin.socle.site.src.logomobile:
+jcmsplugin.socle.site.logo.style:
 jcmsplugin.socle.site.src.carte.pdcv: https://design.loire-atlantique.fr/assets/images/cd44-carte-secteurs-desktop.svg
 jcmsplugin.socle.site.src.carte.pdcv.mobile: https://design.loire-atlantique.fr/assets/images/cd44-carte-secteurs-mobile.svg
 jcmsplugin.socle.site.header.cat: 


### PR DESCRIPTION
Ajout d'une propriété pour avoir une classe spécifique sur le logo du header.
Sera utilisé pour handicap. La gestion du style est déjà présente mais il manquait la propriété.