### PR TITLE
Refacto : récupération et enregistrement des metadatas infolocale

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/EvenementContent.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/EvenementContent.java
@@ -26,8 +26,6 @@ public class EvenementContent extends Content {
     String titre;
     String metadata1;
     String metadata2;
-    String icon1;
-    String icon2;
     
     public EvenementContent() {}
     
@@ -103,21 +101,5 @@ public class EvenementContent extends Content {
 
     public void setMetadata2(String metadata2) {
         this.metadata2 = metadata2;
-    }
-
-    public String getIcon1() {
-        return icon1;
-    }
-
-    public void setIcon1(String icon1) {
-        this.icon1 = icon1;
-    }
-
-    public String getIcon2() {
-        return icon2;
-    }
-
-    public void setIcon2(String icon2) {
-        this.icon2 = icon2;
     }
 }

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -38,10 +38,17 @@ public class InfolocaleEntityUtils {
      * Créé un tableau d'évenements infolocale à partir de JSON
      */
     public static EvenementInfolocale[] createEvenementInfolocaleArrayFromJsonArray(JSONArray jsonArray) {
+      return createEvenementInfolocaleArrayFromJsonArray(jsonArray, null, null);
+    }
+    
+    /**
+     * Créé un tableau d'évenements infolocale à partir de JSON
+     */
+    public static EvenementInfolocale[] createEvenementInfolocaleArrayFromJsonArray(JSONArray jsonArray, String metadata1, String metadata2) {
         EvenementInfolocale[] itEvents = new EvenementInfolocale[jsonArray.length()];
         for (int counter = 0; counter < jsonArray.length(); counter++) {
             try {
-                itEvents[counter] = createEvenementInfolocaleFromJsonItem(jsonArray.getJSONObject(counter));
+                itEvents[counter] = createEvenementInfolocaleFromJsonItem(jsonArray.getJSONObject(counter), metadata1, metadata2);
             } catch (JSONException e) {
                 LOGGER.error("Erreur in createEvenementInfolocaleArrayFromJsonArray: " + e.getMessage());
             }
@@ -51,8 +58,19 @@ public class InfolocaleEntityUtils {
     
     /**
      * Créé un événement infolocale depuis du JSON
+     * @param metadata2 
+     * @param metadata1 
      */
     public static EvenementInfolocale createEvenementInfolocaleFromJsonItem(JSONObject json) {
+      return createEvenementInfolocaleFromJsonItem(json, null, null);
+    }
+    
+    /**
+     * Créé un événement infolocale depuis du JSON
+     * @param metadata2 
+     * @param metadata1 
+     */
+    public static EvenementInfolocale createEvenementInfolocaleFromJsonItem(JSONObject json, String metadata1, String metadata2) {
         if (Util.isEmpty(json)) return null;
         
         EvenementInfolocale itEvent = new EvenementInfolocale();
@@ -100,6 +118,13 @@ public class InfolocaleEntityUtils {
             }
             itEvent.setUrlAnnonce(json.getString("urlAnnonce"));
             itEvent.setUrlOrganisme(json.getString("urlOrganisme"));
+            
+            if (Util.notEmpty(metadata1)) {
+              itEvent.setMetadata1(InfolocaleMetadataUtils.getMetadataHtml(metadata1, json));
+            }
+            if (Util.notEmpty(metadata2)) {
+              itEvent.setMetadata2(InfolocaleMetadataUtils.getMetadataHtml(metadata2, json));
+            }
         } catch (JSONException e) {
             LOGGER.error("Erreur in createEvenementInfolocaleFromJsonItem: " + e.getMessage());
             itEvent = new EvenementInfolocale();

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -36,6 +36,8 @@ public class InfolocaleEntityUtils {
     
     /**
      * Créé un tableau d'évenements infolocale à partir de JSON
+     * @param jsonArray
+     * @return
      */
     public static EvenementInfolocale[] createEvenementInfolocaleArrayFromJsonArray(JSONArray jsonArray) {
       return createEvenementInfolocaleArrayFromJsonArray(jsonArray, null, null);
@@ -43,6 +45,10 @@ public class InfolocaleEntityUtils {
     
     /**
      * Créé un tableau d'évenements infolocale à partir de JSON
+     * @param jsonArray
+     * @param metadata1
+     * @param metadata2
+     * @return
      */
     public static EvenementInfolocale[] createEvenementInfolocaleArrayFromJsonArray(JSONArray jsonArray, String metadata1, String metadata2) {
         EvenementInfolocale[] itEvents = new EvenementInfolocale[jsonArray.length()];
@@ -58,8 +64,8 @@ public class InfolocaleEntityUtils {
     
     /**
      * Créé un événement infolocale depuis du JSON
-     * @param metadata2 
-     * @param metadata1 
+     * @param json
+     * @return
      */
     public static EvenementInfolocale createEvenementInfolocaleFromJsonItem(JSONObject json) {
       return createEvenementInfolocaleFromJsonItem(json, null, null);
@@ -67,8 +73,10 @@ public class InfolocaleEntityUtils {
     
     /**
      * Créé un événement infolocale depuis du JSON
-     * @param metadata2 
-     * @param metadata1 
+     * @param json
+     * @param metadata1
+     * @param metadata2
+     * @return
      */
     public static EvenementInfolocale createEvenementInfolocaleFromJsonItem(JSONObject json, String metadata1, String metadata2) {
         if (Util.isEmpty(json)) return null;

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
@@ -279,15 +279,17 @@ public class RequestManager {
           switch (status) {
                       
               case 200:
-                  if (Util.isEmpty(metadata)) {
+                  String responseContent = SocleUtils.convertStreamToString(response.getEntity().getContent());
+                  if (Util.isEmpty(metadata) || Util.notEmpty(responseContent)) {
                     fluxData = new JSONObject();
-                    fluxData.put("listMetadata", new JSONArray(SocleUtils.convertStreamToString(response.getEntity().getContent())));
+                    fluxData.put("listMetadata", new JSONArray(responseContent));
                   } else {
-                    fluxData = new JSONObject(SocleUtils.convertStreamToString(response.getEntity().getContent()));
+                    fluxData = new JSONObject(responseContent);
                   }
                   fluxData.put(success, true);
                   
                   fluxData.put("dataType", Util.isEmpty(metadata) ? "list" : "single"); // pour déterminer si on a eu le résultat attendu
+                  break;
               case 401:
                   LOGGER.warn(methodGetFluxMetadataError + status + ". Token expiré.");
                   expiredToken = true;

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
@@ -140,9 +140,10 @@ public class InfolocaleUtil {
      */
     public static DateInfolocale getClosestDate(EvenementInfolocale event) {
         
-        if (Util.isEmpty(event)) return null;
+        if (Util.isEmpty(event) || Util.isEmpty(event.getDates())) return null;
         
         DateInfolocale[] allDates = event.getDates();
+        
         DateInfolocale value = null;
         
         Calendar cal = Calendar.getInstance();

--- a/plugins/SoclePlugin/types/PortletAgendaInfolocale/doPortletAgendaInfolocaleBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletAgendaInfolocale/doPortletAgendaInfolocaleBoxDisplay.jsp
@@ -52,7 +52,7 @@ boolean fluxSuccess = Boolean.parseBoolean(extractedFlux.getString("success"));
 <jalios:select>
     <jalios:if predicate='<%= fluxSuccess && extractedFlux.getJSONArray("result").length() > 0 %>'>
         <%
-        EvenementInfolocale[] evenements = InfolocaleEntityUtils.createEvenementInfolocaleArrayFromJsonArray(extractedFlux.getJSONArray("result"));
+        EvenementInfolocale[] evenements = InfolocaleEntityUtils.createEvenementInfolocaleArrayFromJsonArray(extractedFlux.getJSONArray("result"), box.getMetadonneesTuileCarrousel_1(), box.getMetadonneesTuileCarrousel_2());
         List<EvenementInfolocale> allEvents = InfolocaleUtil.splitEventListFromDateFields(evenements);
         List<EvenementInfolocale> sortedEvents = InfolocaleUtil.sortEvenementsCarrousel(allEvents);
         int maxTuiles = evenements.length <= 3 ? evenements.length : 3;
@@ -112,11 +112,11 @@ boolean fluxSuccess = Boolean.parseBoolean(extractedFlux.getString("success"));
                                         <span class="ds44-iconInnerText"><%= itEvent.getLieu().getCommune().getNom() %></span></p>
                                         </jalios:if>
                                         <% String metaCommune = channel.getProperty("jcmsplugin.socle.infolocale.metadata.front.commune"); %>
-                                        <jalios:if predicate="<%= Util.notEmpty(box.getMetadonneesTuileCarrousel_1()) && !box.getMetadonneesTuileCarrousel_1().equals(metaCommune) %>">
-                                            <%= InfolocaleMetadataUtils.getMetadataHtml(box.getMetadonneesTuileCarrousel_1(), itEvent, extractedFlux.getJSONArray("result")) %>
+                                        <jalios:if predicate="<%= Util.notEmpty(box.getMetadonneesTuileCarrousel_1()) && !box.getMetadonneesTuileCarrousel_1().equals(metaCommune) && Util.notEmpty(itEvent.getMetadata1()) %>">
+                                            <%= itEvent.getMetadata1() %>
                                         </jalios:if>
-                                        <jalios:if predicate="<%= Util.notEmpty(box.getMetadonneesTuileCarrousel_2()) && !box.getMetadonneesTuileCarrousel_2().equals(metaCommune) %>">
-                                            <%= InfolocaleMetadataUtils.getMetadataHtml(box.getMetadonneesTuileCarrousel_2(), itEvent, extractedFlux.getJSONArray("result")) %>
+                                        <jalios:if predicate="<%= Util.notEmpty(box.getMetadonneesTuileCarrousel_2()) && !box.getMetadonneesTuileCarrousel_2().equals(metaCommune) && Util.notEmpty(itEvent.getMetadata2()) %>">
+                                            <%= itEvent.getMetadata2() %>
                                         </jalios:if>
                                         <a href="<%= itEvent.getDisplayUrl(userLocale) %>" tabindex="-1" aria-hidden="true" data-a11y-exclude="true"><i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>
                                         <span class="visually-hidden"><%= itEvent.getTitre() %></span></a>


### PR DESCRIPTION
Les mettre en place dès la génération des événements plutôt que de piocher dans le flux json