### PR TITLE
Fix city card

### DIFF
--- a/plugins/SoclePlugin/jsp/cards/doCityCard.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doCityCard.jsp
@@ -17,7 +17,6 @@ boolean hasBottomInfos = Util.notEmpty(pub.getMayor()) || Util.notEmpty(pub.getC
                          || Util.notEmpty(pub.getPostalBox()) || Util.notEmpty(pub.getZipCode());
 
 %>
-
 <section class="ds44-card ds44-js-card ds44-card--contact ds44-bgGray">
     <div class="ds44-card__section">
         <div class="ds44-innerBoxContainer">
@@ -27,11 +26,19 @@ boolean hasBottomInfos = Util.notEmpty(pub.getMayor()) || Util.notEmpty(pub.getC
             <jalios:if predicate="<%= hasBottomInfos %>">
 	            <hr class="mbs" aria-hidden="true">
 	            <jalios:if predicate="<%= Util.notEmpty(pub.getMayor()) %>">
-	            <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-user ds44-docListIco" aria-hidden="true"></i><strong><%= glp("jcmsplugin.socle.maire") %> :</strong> <%= pub.getMayor() %></p>
+	               <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-user ds44-docListIco" aria-hidden="true"></i><strong><%= glp("jcmsplugin.socle.maire") %> :</strong> <%= pub.getMayor() %></p>
 	            </jalios:if>
-	            <div class="ds44-docListElem ds44-mt-std"><i class="icon icon-marker ds44-docListIco" aria-hidden="true"></i>
-	                <jalios:wysiwyg><%= pub.getCouncilBuildingAddress().substring(0, pub.getCouncilBuildingAddress().lastIndexOf("</p></div>")) + "<br/>" + SocleUtils.formatAddress(null, null, null, null, null, null, pub.getPostalBox(), pub.getZipCode(), pub.getTitle(), null) + "</p></div>" %></jalios:wysiwyg>
-	            </div>
+	            <jalios:if predicate="<%= Util.notEmpty(pub.getCouncilBuildingAddress()) %>">
+	            <% 
+	            String adresseMairie = pub.getCouncilBuildingAddress();
+	            if(pub.getCouncilBuildingAddress().replaceAll("\r\n","").lastIndexOf("</p></div>") != -1){
+	            	adresseMairie = pub.getCouncilBuildingAddress().substring(0, pub.getCouncilBuildingAddress().replaceAll("\r\n","").lastIndexOf("</p></div>"));
+	            }
+	            %>
+		            <div class="ds44-docListElem ds44-mt-std"><i class="icon icon-marker ds44-docListIco" aria-hidden="true"></i>
+		                <jalios:wysiwyg><%= adresseMairie + "<br/>" + SocleUtils.formatAddress(null, null, null, null, null, null, pub.getPostalBox(), pub.getZipCode(), pub.getTitle(), null) + "</p></div>" %></jalios:wysiwyg>
+		            </div>
+	           </jalios:if>    
             </jalios:if>
         </div>
         <i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>


### PR DESCRIPTION
Genere  une exception si l'adresse mairie n'a pas le format attendu : certaines adresses n'ont pas les balises <div><p>...</p></div>.
Ce correctif permettra de les identifier sur le moteur de recherche des communes et de les corriger, en les éditant puis en  les enregistrant pour rétablir une structure des zones wysiwyg correcte..