### PR TITLE
Fix formulaires

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -74,7 +74,7 @@ jcmsplugin.socle.recherche.facettes.commune.autocomplete.title: Sélectionner Co
 #  Formulaires
 # ------------------------------------------------------------
 $jcmsplugin.socle.form.portlet-rgpd.id : ID de la portlet Wysiwyg pour les mentions RGPD des formulaires
-jcmsplugin.socle.form.candidature-spontanee.titre: Formulaire de candidature
+jcmsplugin.socle.form.candidature-spontanee.titre: Formulaire de candidature spontanée
 jcmsplugin.socle.form.contact.titre: Formulaire de contact
 jcmsplugin.socle.form.invalidfields: Ces champs ne sont pas valides, merci de les vérifier :
 jcmsplugin.socle.form.exemple.email: Exemple : monadresse@mail.com

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -28,9 +28,6 @@ jcmsplugin.socle.contact-faq.default-mail: Mail de contact par défaut dans les 
 jcmsplugin.socle.portletPush.ficheactu.id: ID Jalios de la portlet Push à afficher dans les fiches actu
 jcmsplugin.socle.site.pdcv.portlet.id: ID Jalios de la portlet Facette pour la recherche PDCV
 jcmsplugin.socle.ficheaide.tuile.tag.root: ID de la catégorie tag pour les tuiles "Fiche Aide"
-jcmsplugin.socle.rgpd.form.text: RGPD : texte en bas des formulaires
-jcmsplugin.socle.rgpd.form.linklabel: RGPD : libellé du lien "En savoir +" en bas des formulaires
-jcmsplugin.socle.rgpd.pub.id: RGPD : ID de la page RGPD
 jcmsplugin.socle.recherche.geojson.departement.url: URL du geojson du département
 jcmsplugin.socle.recherche.geojson.communes.url: URL du geojson des communes
 jcmsplugin.socle.recherche.geojson.epci.url: URL du geojson des epci
@@ -73,7 +70,8 @@ jcmsplugin.socle.recherche.facettes.commune.autocomplete.title: Sélectionner Co
 # ------------------------------------------------------------
 #  Formulaires
 # ------------------------------------------------------------
-$jcmsplugin.socle.form.portlet-rgpd.id : ID de la portlet Wysiwyg pour les mentions RGPD des formulaires
+jcmsplugin.socle.form.contact.portlet-rgpd.id : ID de la portlet Wysiwyg pour les mentions RGPD du formulaire contact
+jcmsplugin.socle.form.candidature.portlet-rgpd.id : ID de la portlet Wysiwyg pour les mentions RGPD du formulaire candidature
 jcmsplugin.socle.form.candidature-spontanee.titre: Formulaire de candidature spontanée
 jcmsplugin.socle.form.contact.titre: Formulaire de contact
 jcmsplugin.socle.form.invalidfields: Ces champs ne sont pas valides, merci de les vérifier :

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -51,13 +51,6 @@ $jcmsplugin.socle.cat.root: j_3
 
 jcmsplugin.socle.footer.portletcontact.id : c_1275593
 
-# ------------------------------------------------------------
-#  RGPD
-# ------------------------------------------------------------
-jcmsplugin.socle.rgpd.form.text: Les informations personnelles vous concernant sont collectées et traitées par le Département de Loire-Atlantique aux fins \
-d’instruction et de réponse aux demandes reçues.
-jcmsplugin.socle.rgpd.form.linklabel: En savoir plus sur la protection des données personnelles
-jcmsplugin.socle.rgpd.pub.id:
 
 # ------------------------------------------------------------
 #  Header
@@ -295,7 +288,8 @@ jcmsplugin.socle.form.candidature.mailTo: AdmimailRecette.DSN-SIN@loire-atlantiq
 jcmsplugin.socle.email.sujet.prefix: Loire-Atlantique.fr
 jcmsplugin.socle.email.candidature-spontanee.titre: Candidature spontanée
 jcmsplugin.socle.rayon.option: rayon
-$jcmsplugin.socle.form.portlet-rgpd.id: 
+jcmsplugin.socle.form.contact.portlet-rgpd.id: 
+jcmsplugin.socle.form.candidature.portlet-rgpd.id: 
 
 # Catégorie racine pour les rayons agenda
 jcmsplugin.socle.rayon.agenda.root.id: c_1301887

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -288,8 +288,8 @@ jcmsplugin.socle.form.candidature.mailTo: AdmimailRecette.DSN-SIN@loire-atlantiq
 jcmsplugin.socle.email.sujet.prefix: Loire-Atlantique.fr
 jcmsplugin.socle.email.candidature-spontanee.titre: Candidature spontanée
 jcmsplugin.socle.rayon.option: rayon
-jcmsplugin.socle.form.contact.portlet-rgpd.id: 
-jcmsplugin.socle.form.candidature.portlet-rgpd.id: 
+jcmsplugin.socle.form.contact.portlet-rgpd.id: c_1304194
+jcmsplugin.socle.form.candidature.portlet-rgpd.id: c_1305481
 
 # Catégorie racine pour les rayons agenda
 jcmsplugin.socle.rayon.agenda.root.id: c_1301887

--- a/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf
+++ b/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf
@@ -1,9 +1,11 @@
 <%@page import="generated.PortletWYSIWYG"%>
 <%@ page contentType="text/html; charset=UTF-8"%>
-    
-		<jalios:if predicate='<%= Util.notEmpty(channel.getData("$jcmsplugin.socle.form.portlet-rgpd.id")) %>'>
+<%
+String idPortletBas = (String) request.getAttribute("idPortletBas");
+%>    
+		<jalios:if predicate='<%= Util.notEmpty(channel.getData(idPortletBas)) %>'>
 		      <jalios:wysiwyg css="ds44-wsg-smallText ds44-mt3">
-		          <%= ((PortletWYSIWYG) channel.getData("$jcmsplugin.socle.form.portlet-rgpd.id")).getWysiwyg() %>
+		          <%= ((PortletWYSIWYG) channel.getData(idPortletBas)).getWysiwyg() %>
 		      </jalios:wysiwyg>
 		</jalios:if>
 

--- a/plugins/SoclePlugin/types/CandidatureSpontaneeForm/doEditCandidatureSpontaneeForm.jsp
+++ b/plugins/SoclePlugin/types/CandidatureSpontaneeForm/doEditCandidatureSpontaneeForm.jsp
@@ -215,7 +215,7 @@ natureRechercheCatSet.addAll(formHandler.getNatureRechercheRoot().getChildrenSet
     <div class="ds44-form__container">
         <div class="ds44-posRel">
             <label id="label-form-element-complement1" for="form-element-complement1" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel1 %><sup aria-hidden="true">*</sup></span></span>
+                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel1 %></span></span>
             </label>
             
             <div class="ds44-file__shape ds44-inpStd">
@@ -245,7 +245,7 @@ natureRechercheCatSet.addAll(formHandler.getNatureRechercheRoot().getChildrenSet
     <div class="ds44-form__container">
         <div class="ds44-posRel">
             <label id="label-form-element-complement1" for="form-element-complement2" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel2 %><sup aria-hidden="true">*</sup></span></span>
+                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel2 %></span></span>
             </label>
             
             <div class="ds44-file__shape ds44-inpStd">
@@ -275,7 +275,7 @@ natureRechercheCatSet.addAll(formHandler.getNatureRechercheRoot().getChildrenSet
     <div class="ds44-form__container">
         <div class="ds44-posRel">
             <label id="label-form-element-complement3" for="form-element-complement3" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel3 %><sup aria-hidden="true">*</sup></span></span>
+                <span class="ds44-labelTypePlaceholder"><span><%= complementLabel3 %></span></span>
             </label>
             
             <div class="ds44-file__shape ds44-inpStd">

--- a/plugins/SoclePlugin/types/CandidatureSpontaneeForm/editFormCandidatureSpontaneeForm.jsp
+++ b/plugins/SoclePlugin/types/CandidatureSpontaneeForm/editFormCandidatureSpontaneeForm.jsp
@@ -50,4 +50,5 @@ String formAction = "plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp";
 
 </form>
 
+<% request.setAttribute("idPortletBas", channel.getProperty("jcmsplugin.socle.form.candidature.portlet-rgpd.id")); %>
 <%@ include file='/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf' %>

--- a/plugins/SoclePlugin/types/ContactForm/editFormContactForm.jsp
+++ b/plugins/SoclePlugin/types/ContactForm/editFormContactForm.jsp
@@ -49,6 +49,6 @@
         <input type="hidden" name="id" value='<%= request.getParameter("id") %>' data-technical-field />
     
     </form>
-
+<% request.setAttribute("idPortletBas", channel.getProperty("jcmsplugin.socle.form.contact.portlet-rgpd.id")); %>
 <%@ include file='/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf' %>
 

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleTechnique.jspf
@@ -1,6 +1,26 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
-
-<ds:titleNoBanner title="<%= obj.getTitle(userLang) %>" breadcrumb="true"></ds:titleNoBanner>
+<%
+    String imageFile = obj.getImageBandeau();
+    String imageMobileFile = Util.notEmpty(obj.getImageMobile()) ? obj.getImageMobile() : "s.gif";
+    String title = obj.getTitle(userLang);
+    String legende = obj.getLegende(userLang);
+    String copyright = obj.getCopyright(userLang);
+%>
+<jalios:select> 
+    <jalios:if predicate="<%=Util.notEmpty(obj.getImageBandeau()) %>">
+       <ds:titleBanner imagePath="<%= imageFile %>" mobileImagePath="<%= imageMobileFile %>" title="<%= title %>" legend="<%=legende %>"
+        copyright="<%=copyright%>" breadcrumb="true"></ds:titleBanner>
+    </jalios:if>
+    <jalios:if predicate="<%=Util.notEmpty(obj.getImagePrincipale()) %>">
+       <ds:titleSimple imagePath="<%= obj.getImagePrincipale() %>" mobileImagePath="<%= imageMobileFile %>" video="<%=obj.getVideoPrincipale() %>"
+        title="<%= title %>" chapo="<%= obj.getChapo() %>" legend="<%= obj.getLegende() %>" copyright="<%= obj.getCopyright() %>" 
+        breadcrumb="true"></ds:titleSimple> 
+    </jalios:if>    
+  
+    <jalios:default>
+       <ds:titleNoBanner title="<%= title %>" breadcrumb="true"></ds:titleNoBanner>
+    </jalios:default>
+</jalios:select>
 
 <div class="ds44-inner-container ds44-mt4">
 	<div class="grid-12-small-1">


### PR DESCRIPTION
- Modif du libellé du titre pour la candidature spontanée
- Prise en compte du champs image dans l'article embarquant le formulaire
- Suppressions des propriétés RGPD dans les fichiers de prop
- Mentions RGPD dans portlets Wysiwyg rendues paramétrables