### PR TITLE
Evol : insertion unifiée (RS-1247, RS-1280, RS-1281)

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -224,6 +224,9 @@ media.template.tuileHorizontaleGrey.application: /plugins/SoclePlugin/jsp/templa
 # Content template
 media.data-template.default.Content: /plugins/SoclePlugin/jsp/insertionUnifiee/mediaTemplateContent.jsp
 media.data-template.default.ListeDeContenus: /plugins/SoclePlugin/jsp/insertionUnifiee/listeDeContenusTemplate.jsp
+media.data-template.default.FichePublication: /plugins/SoclePlugin/jsp/templates/doFichePublicationTuileHorizontaleGrey.jsp?wysiwygEmbed=true
+media.data-template.default.Contact: /plugins/SoclePlugin/jsp/cards/doContactCard.jsp?wysiwygEmbed=true
+media.data-template.default.ElectedMember: /plugins/SoclePlugin/jsp/cards/doElectedMemberCardFull.jsp?wysiwygEmbed=true
 media.data-template.temoignage.Content: /plugins/SoclePlugin/jsp/templates/temoignageTemplate.jsp
 media.data-template.temoignage.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTemoignages.jsp
 media.data-template.contact.FicheLieu: /plugins/SoclePlugin/types/FicheLieu/doFicheLieuEmbedDisplayContent.jsp

--- a/plugins/SoclePlugin/jsp/cards/doContactCard.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doContactCard.jsp
@@ -15,13 +15,15 @@ String uid = ServletUtil.generateUniqueDOMId(request, "uid");
 
 %>
 
-<section class="ds44-card ds44-box ds44-bgGray">
+<section class='ds44-card ds44-box ds44-bgGray <%= Util.notEmpty(request.getParameter("wysiwygEmbed")) ? "large-w50" : ""%>'>
   <div class="ds44-flex-container ds44-flex-valign-center">
-    <div class="ds44-card__section--horizontal--img">
-      <picture class="ds44-container-imgRatio ds44-container-imgRatio--profil ds44-m-std ">
-       <img src="<%= pub.getPhotoDidentite() %>" alt="" class="ds44-w100 ds44-imgRatio ds44-imgRatio--profil">
-      </picture>
-   </div>
+    <jalios:if predicate='<%= Util.notEmpty(pub.getPhotoDidentite()) %>'>
+	    <div class="ds44-card__section--horizontal--img">
+	      <picture class="ds44-container-imgRatio ds44-container-imgRatio--profil ds44-m-std ">
+	       <img src="<%= pub.getPhotoDidentite() %>" alt="" class="ds44-w100 ds44-imgRatio ds44-imgRatio--profil">
+	      </picture>
+	   </div>
+   </jalios:if>
     <div class="ds44-card__section--horizontal">
       <p role="heading" aria-level="2" class="ds44-card__title" id="tuileContact_<%= uid %>"><%= pub.getTitle() %></p>
       <jalios:if predicate="<%= Util.notEmpty(pub.getCommunes()) %>">

--- a/plugins/SoclePlugin/jsp/cards/doElectedMemberCardFull.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doElectedMemberCardFull.jsp
@@ -29,7 +29,7 @@ if (Util.isEmpty(urlImage)) urlImage = pub.getPicture();
 
 %>
 
-<section class="ds44-card ds44-box ds44-js-card ds44-card--verticalPicture ds44-card--verticalPicture--elu ds44--m-padding-b">
+<section class='ds44-card ds44-box ds44-js-card ds44-card--verticalPicture ds44-card--verticalPicture--elu ds44--m-padding-b <%= Util.notEmpty(request.getParameter("wysiwygEmbed")) ? "large-w50" : ""%>'>
     <picture class="ds44-container-imgRatio ds44-container-imgRatio--profilXL">
         <img src="<%= urlImage %>" alt="" class="ds44-w100 ds44-imgRatio ds44-imgRatio--profil">
     </picture>
@@ -45,12 +45,16 @@ if (Util.isEmpty(urlImage)) urlImage = pub.getPicture();
         <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-tag ds44-docListIco" aria-hidden="true"></i><%= conseillerLabel %></p>
         </jalios:if>
         <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-marker ds44-docListIco" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.adresse") %></span><%= glp("jcmsplugin.socle.facette.canton.default-label") %> : <%= pub.getCanton() %></p>
-        <hr class="mbm mtm" aria-hidden="true">
-        <p class="ds44-mt-std"><%= pub.getPoliticalParty(loggedMember).first() %></p>
-        <% ElectedMember binome = SocleUtils.getElectedMemberBinome(pub); %>
-        <jalios:if predicate="<%= Util.notEmpty(binome) %>">
-        <p class="ds44-mt-std"><%= glp("jcmsplugin.socle.elu.binome", SocleUtils.getElectedMemberFullName(binome)) %></p>
-        </jalios:if>    
+        
+        <%-- On masque certaines infos si la tuile est insérée dans un bloc wysiwyg (insertion unifiée) --%>
+        <jalios:if predicate='<%=Util.isEmpty(request.getParameter("wysiwygEmbed"))%>'>
+	        <hr class="mbm mtm" aria-hidden="true">
+	        <p class="ds44-mt-std"><%= pub.getPoliticalParty(loggedMember).first() %></p>
+	        <% ElectedMember binome = SocleUtils.getElectedMemberBinome(pub); %>
+	        <jalios:if predicate="<%= Util.notEmpty(binome) %>">
+	        <p class="ds44-mt-std"><%= glp("jcmsplugin.socle.elu.binome", SocleUtils.getElectedMemberFullName(binome)) %></p>
+	        </jalios:if>  
+        </jalios:if>  
         <i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>
     </div>
 </section>

--- a/plugins/SoclePlugin/jsp/templates/doFichePublicationTuileHorizontaleGrey.jsp
+++ b/plugins/SoclePlugin/jsp/templates/doFichePublicationTuileHorizontaleGrey.jsp
@@ -13,7 +13,7 @@ FichePublication pub = (FichePublication) data;
 
 %>
 
-<section class="ds44-card ds44-js-card ds44-card--horizontal">
+<section class='ds44-card ds44-js-card ds44-card--horizontal <%= Util.notEmpty(request.getParameter("wysiwygEmbed")) ? "large-w50" : ""%>'>
   <div class="ds44-flex-container ds44-flex-valign-center">
     <div class="ds44-card__section--horizontal--img">
      <ds:figurePicture pub="<%= pub %>" image="<%= pub.getImagePrincipale() %>" format="mobile" pictureCss="ds44-container-imgRatio ds44-container-imgRatio--A4" imgCss="ds44-w100 ds44-imgRatio"


### PR DESCRIPTION
Rajout de déclaration de gabarits pour l'insertion d'élu, de contact et de fiche publication dans les zones wysiwyg.
Réutilisation des gabarits de tuiles du moteur à facettes avec modif des gabarits pour gérer l'affichage de la tuile sur la moitié de son conteneur.