### PR TITLE
Quickfix : anomalie tri agenda + tuile verticale agenda

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
@@ -93,10 +93,13 @@ public class InfolocaleUtil {
           try {
             Date date1 = sdf.parse(o1.getDates()[0].getDebut());
             Date date2 = sdf.parse(o2.getDates()[0].getDebut());
-            return date1.compareTo(date2);
+            if (date1.after(date2)) return -1;
+            if (date2.after(date1)) return 1;
           } catch (ParseException e) {
-            return 0;
+            LOGGER.warn("Exception while comparing events : " + e.getMessage());
           }
+          
+          return 0;
         }
         
       });

--- a/plugins/SoclePlugin/jsp/cards/doEvenementInfolocaleVerticalCard.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doEvenementInfolocaleVerticalCard.jsp
@@ -32,16 +32,18 @@ String urlPhoto = Util.notEmpty(itEvent.getPhotos()) && itEvent.getPhotos().leng
           <hr class="mbs" aria-hidden="true">
           <p class="ds44-docListElem ds44-mt-std">
             <i class="icon icon-date ds44-docListIco" aria-hidden="true"></i>
-            <jalios:select>
-                <jalios:if predicate="<%= InfolocaleUtil.infolocaleDateIsSingleDay(currentDisplayedDate) %>">
-                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getDebut()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getDebut(), false) %>
-                </jalios:if>
-                <jalios:default>
-                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getDebut()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getDebut(), false) %>
-                    -
-                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getFin()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getFin(), false) %>
-                </jalios:default>
-            </jalios:select>
+            <jalios:if predicate="<%= Util.notEmpty(currentDisplayedDate) %>">
+	            <jalios:select>
+	                <jalios:if predicate="<%= InfolocaleUtil.infolocaleDateIsSingleDay(currentDisplayedDate) %>">
+	                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getDebut()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getDebut(), false) %>
+	                </jalios:if>
+	                <jalios:default>
+	                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getDebut()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getDebut(), false) %>
+	                    -
+	                    <%= InfolocaleUtil.getDayOfMonthLabel(currentDisplayedDate.getFin()) %> <%= InfolocaleUtil.getMonthLabel(currentDisplayedDate.getFin(), false) %>
+	                </jalios:default>
+	            </jalios:select>
+            </jalios:if>
           </p>
           
 		  <% String metaCommune = channel.getProperty("jcmsplugin.socle.infolocale.metadata.front.commune"); %>


### PR DESCRIPTION
Le comparateur n'aimait pas qu'on lance un "compareTo" sur des sous-éléments d'objets qui peuvent être identiques. Au final j'ai dû faire l'action 'à la main' plutôt que d'utiliser le natif, pour le même résultat...