### PR TITLE
Fix sur l'ordre des événements - séparation des deux patterns dates infolocale

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
@@ -93,8 +93,8 @@ public class InfolocaleUtil {
           try {
             Date date1 = sdf.parse(o1.getDates()[0].getDebut());
             Date date2 = sdf.parse(o2.getDates()[0].getDebut());
-            if (date1.after(date2)) return -1;
-            if (date2.after(date1)) return 1;
+            if (date1.after(date2)) return 1;
+            if (date2.after(date1)) return -1;
           } catch (ParseException e) {
             LOGGER.warn("Exception while comparing events : " + e.getMessage());
           }

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -427,6 +427,9 @@ jcmsplugin.socle.infolocale.flux.url: https://api.infolocale.fr/flux/
 jcmsplugin.socle.infolocale.extract.url: https://api.infolocale.fr/flux/type/annonces/extract/
 jcmsplugin.socle.infolocale.organisme.dep.id.list: id1,id2,id3
 
+jcmsplugin.socle.infolocale.date.receive.format: yyyy-MM-dd
+jcmsplugin.socle.infolocale.date.send.format: dd-MM-yyyy
+
 # Metadonnees Infolocale pour le front
 
 jcmsplugin.socle.infolocale.metadata.front.commune: commune


### PR DESCRIPTION
Le second point est là car Infolocale utilise deux formats : dd-MM-yyyy quand on doit faire une recherche avec des paramètres de date, et yyyy-MM-dd sur les dates des événements reçus...