### PR TITLE
Fix : affichage de tuiles en colonne droite (RS-1280)

### DIFF
--- a/plugins/SoclePlugin/types/AccueilAnnuaireAgenda/doAccueilAnnuaireAgenda_Annuaire.jsp
+++ b/plugins/SoclePlugin/types/AccueilAnnuaireAgenda/doAccueilAnnuaireAgenda_Annuaire.jsp
@@ -63,7 +63,7 @@
                     <jalios:if predicate="<%= Util.notEmpty(obj.getContenusEncadresLibres()) || Util.notEmpty(obj.getPortletsEncadres()) %>">
                         <div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
 
-                        <aside class="col-4">
+                        <aside class="col-4 asideCards">
                             <jalios:foreach array="<%=obj.getContenusEncadresLibres()%>" type="String"
                                 name="itContenu" counter="itCounter">
                                 <%

--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
@@ -143,7 +143,7 @@ boolean displaySuivreDemande = Util.notEmpty(obj.getIntroSuivreUneDemande()) || 
 
                         <div class="col-1 grid-offset"></div>
 
-                        <aside class="col-4">     
+                        <aside class="col-4 asideCards">     
                             <%@ include file="doFicheAideEncadre.jspf" %>                     
                         </aside>
                         
@@ -200,7 +200,7 @@ boolean displaySuivreDemande = Util.notEmpty(obj.getIntroSuivreUneDemande()) || 
 
                         <div class="col-1 grid-offset"></div>
  
-                        <aside class="col-4">                   
+                        <aside class="col-4 asideCards">                   
                             <%@ include file="doFicheAideEncadre.jspf" %>
                         </aside>
 

--- a/plugins/SoclePlugin/types/FicheArticle/ficheArticleOnglets.jspf
+++ b/plugins/SoclePlugin/types/FicheArticle/ficheArticleOnglets.jspf
@@ -109,7 +109,7 @@
                
                <div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
 
-                <aside class="col-4">
+                <aside class="col-4 asideCards">
                     <%@ include file="doFicheArticleEncadre.jspf"%>
                 </aside>
     	

--- a/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
@@ -38,7 +38,7 @@ String copyright = obj.getCopyright(userLang);
                 
                 <%-- Colonne de droite (affichée systématiquement même si portlets vides) --%>
                 <div class="col-1 grid-offset"></div>
-                <aside class="col-4">
+                <aside class="col-4 asideCards">
     		        <jalios:if predicate="<%= Util.notEmpty(obj.getSideportlets()) %>">
 			            <jalios:foreach name="itPub" array="<%= obj.getSideportlets() %>" type="com.jalios.jcms.Publication">
 			            

--- a/plugins/SoclePlugin/types/WelcomeSection/doWelcomeSectionFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/WelcomeSection/doWelcomeSectionFullDisplay.jsp
@@ -36,7 +36,7 @@
                 
                 <%-- Colonne de droite (affichée systématiquement même si portlets vides) --%>
                 <div class="col-1 grid-offset"></div>
-                <aside class="col-4">                   
+                <aside class="col-4 asideCards">                   
     		        <jalios:if predicate="<%= Util.notEmpty(obj.getTopportlets()) %>">
 			            <jalios:foreach name="itPortlet" array="<%= obj.getTopportlets() %>" type="com.jalios.jcms.Publication">
 			                <jalios:include id="<%= itPortlet.getId() %>" />


### PR DESCRIPTION
Certaines tuile ont une largeur de 50% quand intégrée dans un wysiwyg en partie centrale.
Si ces tuiles sont intégrées en colonne de droite il faut alors qu'elles s'affichent en 100% et pas 50%.
L'ajout d'une classe sur la balise <aside> permet cela.