### PR TITLE
Evol : ajout d'un lien vers JSP dans espace d'admin

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -507,6 +507,7 @@
     <file path="jsp/reprise/repriseFicheLieuLink.jsp" include="ADMIN_OPERATION" />
     <file path="jsp/reprise/repriseAutresTypesLink.jsp" include="ADMIN_OPERATION" />
     <file path="jsp/reprise/repriseContenuContactLink.jsp" include="ADMIN_OPERATION" />
+    <file path="jsp/reprise/contenusSansGeolocLink.jsp" include="ADMIN_OPERATION" />
     <file path="types/FicheArticle/ficheArticleSimple.jspf" />
     <file path="types/FicheArticle/ficheArticleOnglets.jspf" />
     <file path="types/FicheArticle/doFicheArticleEncadre.jspf" />

--- a/plugins/SoclePlugin/jsp/reprise/contenusSansGeolocLink.jsp
+++ b/plugins/SoclePlugin/jsp/reprise/contenusSansGeolocLink.jsp
@@ -1,0 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ include file="/jcore/doInitPage.jsp" %>
+
+<a class="list-group-item admin-item-logs" href="plugins/SoclePlugin/jsp/reprise/contenusSansGeoloc.jsp"><span class="jalios-icon log-icon icomoon-clipboard3"></span> Liste des contenus sans géoloc</a>


### PR DESCRIPTION
Pour faciliter accès à la page listant les contenus sans géolocalisation.