### PR TITLE
Fix : sur le portail de recherche facette, les champs doivent être en standard

### DIFF
--- a/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf
+++ b/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf
@@ -1,0 +1,4 @@
+<%
+Publication publication = (Publication) request.getAttribute(PortalManager.PORTAL_PUBLICATION);
+Boolean isInRechercheFacette = Util.isEmpty(publication);
+%>

--- a/plugins/SoclePlugin/types/PortletFacetteAdresse/doPortletFacetteAdresseBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteAdresse/doPortletFacetteAdresseBoxDisplay.jsp
@@ -1,8 +1,11 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
-<% PortletFacetteAdresse obj = (PortletFacetteAdresse)portlet; %>
+<% 
+PortletFacetteAdresse obj = (PortletFacetteAdresse)portlet;
+%>
 
 <ds:facetteAutoCompletion idFormElement='<%= ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element")) %>' 
 		name="adresse" 
@@ -13,4 +16,5 @@
 		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.adresse.default-label") %>'
 		option='<%= Util.notEmpty(obj.getRayon(loggedMember)) ? "rayon" : "" %>'
 		setRayons="<%= Util.notEmpty(obj.getRayon(loggedMember)) ? obj.getRayon(loggedMember) : new TreeSet<Category>() %>"
-		autourMoi="<%= obj.getAutourDeMoi() %>"/>
+		autourMoi="<%= obj.getAutourDeMoi() %>"
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteAgendaAccessibilit/doPortletFacetteAgendaAccessibilitBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteAgendaAccessibilit/doPortletFacetteAgendaAccessibilitBoxDisplay.jsp
@@ -3,6 +3,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
 <% PortletFacetteAgendaAccessibilit obj = (PortletFacetteAgendaAccessibilit)portlet; %>
 
@@ -18,7 +19,7 @@ boolean isRequired = obj.getFacetteObligatoire();
 %>
 
 <div class="ds44-form__container">
-   <div class="ds44-select__shape ds44-inpLarge ds44-inpStd">
+   <div class='ds44-select__shape <%= isInRechercheFacette ? "" : "ds44-inpLarge" %> ds44-inpStd'>
       <p id="label-<%= uid %>" class="ds44-selectLabel" aria-hidden="true"><%= glp("jcmsplugin.socle.infolocale.label.accessibilite") %>
         <jalios:if predicate="<%= isRequired %>"><sup aria-hidden="true"><%= glp("jcmsplugin.socle.facette.asterisque") %></sup></jalios:if>
       </p>

--- a/plugins/SoclePlugin/types/PortletFacetteAgendaCommune/doPortletFacetteAgendaCommuneBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteAgendaCommune/doPortletFacetteAgendaCommuneBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <% 
 	PortletFacetteAgendaCommune obj = (PortletFacetteAgendaCommune)portlet;
@@ -24,4 +25,5 @@
 		dataUrl="<%= dataUrl %>" 
 		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.commune.default-label") %>'
 		option='<%= channel.getProperty("jcmsplugin.socle.rayon.option") %>'
-		setRayons='<%= rayonRoot.getChildrenSet() %>'/>
+		setRayons='<%= rayonRoot.getChildrenSet() %>'
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteAgendaDate/doPortletFacetteAgendaDateBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteAgendaDate/doPortletFacetteAgendaDateBoxDisplay.jsp
@@ -3,6 +3,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
 <% PortletFacetteAgendaDate obj = (PortletFacetteAgendaDate)portlet; %>
 
@@ -20,7 +21,7 @@ boolean isRequired = obj.getFacetteObligatoire();
  
 
 <div class="ds44-form__container">
-   <div class="ds44-select__shape ds44-inpStd ds44-inpLarge">
+   <div class='ds44-select__shape ds44-inpStd <%= isInRechercheFacette ? "" : "ds44-inpLarge" %>'>
       <p id="label-<%= uid %>" class="ds44-selectLabel" aria-hidden="true"><%= title %><sup aria-hidden="true"><%= isRequired ? glp("jcmsplugin.socle.facette.asterisque") : "" %></sup></p>
       <div id="<%= uid %>" data-name="agenda-date" class="ds44-js-select-radio ds44-selectDisplay"  data-required="<%= isRequired %>"></div>
       <button class="ds44-reset" type="button" aria-describedby="label-<%= uid %>"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", title) %></span></button>

--- a/plugins/SoclePlugin/types/PortletFacetteCanton/doPortletFacetteCantonBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteCanton/doPortletFacetteCantonBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <%
 	PortletFacetteCanton obj = (PortletFacetteCanton) portlet;
@@ -14,4 +15,5 @@
 		isFacetteObligatoire="<%= obj.getFacetteObligatoire() %>" 
 		dataMode="select-only" 
 		dataUrl="plugins/SoclePlugin/jsp/facettes/acSearchPublication.jsp?query=types%3Dgenerated.Canton&sort=title" 
-		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.canton.default-label") %>'/>
+		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.canton.default-label") %>'
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteCommune/doPortletFacetteCommuneBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteCommune/doPortletFacetteCommuneBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <% 
 	PortletFacetteCommune obj = (PortletFacetteCommune)portlet;
@@ -20,4 +21,5 @@
 		dataMode="select-only" 
 		dataUrl="<%= dataUrl %>" 
 		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.commune.default-label") %>'
-		option='<%= Util.isEmpty(obj.getRechercheEtendue()) || obj.getRechercheEtendue().equalsIgnoreCase("aucune") ? "" : obj.getRechercheEtendue() %>'/>
+		option='<%= Util.isEmpty(obj.getRechercheEtendue()) || obj.getRechercheEtendue().equalsIgnoreCase("aucune") ? "" : obj.getRechercheEtendue() %>'
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteCommuneAdresseLiee/doPortletFacetteCommuneAdresseLieeBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteCommuneAdresseLiee/doPortletFacetteCommuneAdresseLieeBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
 <% 
 	PortletFacetteCommuneAdresseLiee obj = (PortletFacetteCommuneAdresseLiee)portlet; 
@@ -15,4 +16,5 @@
 		dataMode="select-only" 
 		dataUrl="plugins/SoclePlugin/jsp/facettes/acSearchCommune.jsp" 
 		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.commune.default-label") %>'
-		option="adresse"/>
+		option="adresse"
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteDelegation/doPortletFacetteDelegationBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteDelegation/doPortletFacetteDelegationBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <% 
 	PortletFacetteDelegation obj = (PortletFacetteDelegation)portlet; 
@@ -14,4 +15,5 @@
 		isFacetteObligatoire="<%= obj.getFacetteObligatoire() %>" 
 		dataMode="select-only" 
 		dataUrl="plugins/SoclePlugin/jsp/facettes/acSearchPublication.jsp?query=types%3Dgenerated.Delegation" 
-		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.delegation.default-label") %>'/>
+		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.delegation.default-label") %>'
+		isLarge='<%= !isInRechercheFacette %>'/>

--- a/plugins/SoclePlugin/types/PortletFacetteDelegation/doPortletSearchPdcv.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteDelegation/doPortletSearchPdcv.jsp
@@ -1,5 +1,6 @@
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 
 <% 
@@ -55,7 +56,8 @@ if(Util.notEmpty(delegation)){
 		        dataMode="select-only" 
 		        dataUrl="<%= dataUrl %>" 
 		        label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.commune.default-label") %>'
-		        option='<%= Util.isEmpty(delegation) || (Util.notEmpty(delegation) && Util.arrayContains(channel.getStringArrayProperty("jcmsplugin.socle.delegation.needAddress", null), delegation.getCodePostal())) ? "adresse" : "" %>'/>		        
+		        option='<%= Util.isEmpty(delegation) || (Util.notEmpty(delegation) && Util.arrayContains(channel.getStringArrayProperty("jcmsplugin.socle.delegation.needAddress", null), delegation.getCodePostal())) ? "adresse" : "" %>'
+		        isLarge='<%= !isInRechercheFacette %>'/>		        
 	</jalios:default>
 	
 </jalios:select>

--- a/plugins/SoclePlugin/types/PortletFacetteTitre/doPortletFacetteTitreBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteTitre/doPortletFacetteTitreBoxDisplay.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
 <% 
 	PortletFacetteTitre obj = (PortletFacetteTitre)portlet; 
@@ -20,4 +21,5 @@
 		isFacetteObligatoire="<%= obj.getFacetteObligatoire() %>" 
 		dataMode="free-text" 
 		dataUrl='<%= dataUrl %>' 
-		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.titre.default-label") %>'/>
+		label='<%= Util.notEmpty(obj.getLabel()) ? obj.getLabel() : glp("jcmsplugin.socle.facette.titre.default-label") %>'
+		isLarge='<%= !isInRechercheFacette %>'/>


### PR DESCRIPTION
Voir page DS http://dev-design.loire-atlantique.fr/templates/page-resultats-recherche.html