### PR TITLE
Fix page utile

### DIFF
--- a/plugins/SoclePlugin/jsp/forms/checkPageUtile.jsp
+++ b/plugins/SoclePlugin/jsp/forms/checkPageUtile.jsp
@@ -31,10 +31,6 @@ boolean isOK = true;
 // Réponse "Oui"
 if (request.getParameter("utile[value]").equals("true")) {
   pageUtile = true;  
-  if (Util.isEmpty(commentaire)) {
-	  isOK = false;
-	  jsonArray.add(glp("jcmsplugin.socle.form.champ-obligatoire", "Commentaire"));
-	}
   
 }
 //Réponse "Non"

--- a/plugins/SoclePlugin/jsp/mail/formulairePageUtileTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/mail/formulairePageUtileTemplate.jsp
@@ -305,10 +305,14 @@ MOBILE TARGETING
                         <td>
                         <p>Le : <%=request.getAttribute("date") %></p>
                         <p><%=request.getAttribute("avis") %> : <a href="<%=request.getAttribute("lien") %>" target="_blank"><%=request.getAttribute("titre") %></a></p>
+                        
                         <% if(null != request.getAttribute("motif")){ %>
-                        <p>Pourquoi : <%=request.getAttribute("motif") %></p>
+                            <p>Pourquoi : <%=request.getAttribute("motif") %></p>
                         <%} %>
-                        <p>COMMENTAIRE : <%=request.getAttribute("commentaire") %></p>
+                        
+                        <% if(null != request.getAttribute("commentaire")){ %>
+                            <p>COMMENTAIRE : <%=request.getAttribute("commentaire") %></p>
+                        <%} %>
                         </td>
                       </tr>
                     </tbody>

--- a/plugins/SoclePlugin/types/AccueilDelegation/doAccueilDelegationFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/AccueilDelegation/doAccueilDelegationFullDisplay.jsp
@@ -81,8 +81,6 @@
     <%@ include file="/plugins/SoclePlugin/jsp/portal/socialNetworksShare.jspf" %>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>    
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
         
 </main>

--- a/plugins/SoclePlugin/types/Canton/doCantonFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Canton/doCantonFullDisplay.jsp
@@ -88,9 +88,7 @@ List<String> remplacants = new ArrayList<String>();
     </article>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
 
 
 </main>

--- a/plugins/SoclePlugin/types/City/doCityFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/City/doCityFullDisplay.jsp
@@ -210,9 +210,7 @@ String localisation = SocleUtils.formatOpenStreetMapLink(latitude, longitude);
     </jalios:if>
         
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
 
 </main>
 

--- a/plugins/SoclePlugin/types/FicheActionEducative/doFicheActionEducativeFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheActionEducative/doFicheActionEducativeFullDisplay.jsp
@@ -278,8 +278,6 @@ boolean hasParcoursCollege = obj.getCategorySet().contains(channel.getCategory("
     </article>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
     
 </main>

--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
@@ -247,9 +247,7 @@ boolean displaySuivreDemande = Util.notEmpty(obj.getIntroSuivreUneDemande()) || 
     </section>
 
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
 
 </main>
 

--- a/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheArticle/doFicheArticleFullDisplay.jsp
@@ -27,9 +27,7 @@
     </article>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
     
     <%-- Portlets bas --%>
     <jalios:if predicate="<%= Util.notEmpty(obj.getBottomportlets()) %>">

--- a/plugins/SoclePlugin/types/FicheLieu/doFicheLieuFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheLieu/doFicheLieuFullDisplay.jsp
@@ -504,8 +504,6 @@
 </article>
 
 <%-- Page utile --%>
-<jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-</jalios:if>
+<jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
      
 </main>

--- a/plugins/SoclePlugin/types/FichePublication/doFichePublicationFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FichePublication/doFichePublicationFullDisplay.jsp
@@ -208,8 +208,6 @@
     </jalios:if>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>    
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>   
 
 </main>

--- a/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheSAAD/doFicheSAADFullDisplay.jsp
@@ -112,8 +112,6 @@ String localisation = SocleUtils.formatOpenStreetMapLink(latitude, longitude);
     </article>
     
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
     
 </main>

--- a/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp
+++ b/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %><%
 %><%@ include file='/jcore/doInitPage.jspf' %>
 
-<jalios:if predicate='<%= channel.isDataWriteEnabled() %>'>
+<jalios:if predicate='<%= channel.isDataWriteEnabled() && ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) && Util.isEmpty(request.getAttribute("isSearchFacetPanel")) %>'>
         <jsp:include page="doEditPageUtileForm.jsp" />
 </jalios:if>
 

--- a/plugins/SoclePlugin/types/SeniorCitizensEstablishment/doSeniorCitizensEstablishmentFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/SeniorCitizensEstablishment/doSeniorCitizensEstablishmentFullDisplay.jsp
@@ -370,8 +370,6 @@
 	</article>
 	
     <%-- Page utile --%>
-    <jalios:if predicate='<%= ! channel.getBooleanProperty("jcmsplugin.socle.page-utile.disabled", true) %>'>
-        <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
-    </jalios:if>
+    <jsp:include page="/plugins/SoclePlugin/types/PageUtileForm/editFormPageUtileForm.jsp"/>
     	
 </main>


### PR DESCRIPTION
Changement de règle sur contrôle de saisie du formulaire.
Ajout d'une règle d'affichage pour ne pas afficher le bloc "page utile" quand on est en résultat de recherche latérale du moteur à facettes.