### PR TITLE
fix mail candidature

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
@@ -26,7 +26,7 @@ public final class MailUtils {
 	private static Channel channel = Channel.getChannel();
 
 	private static final Logger LOGGER = Logger.getLogger(MailUtils.class);
-	private static final String NEWLINE = "\n";
+	private static final String NEWLINE = "<br>";
 
 	private MailUtils() {
 		throw new IllegalStateException("Utility class");
@@ -272,7 +272,8 @@ public final class MailUtils {
 	 * @param jsp La JSP du template de mail à envoyer
 	 * @param parametersMap La map contenant les données à placer dans le template JSP
 	 */
-	public static void sendMail(String subject, String content, String emailFrom, String emailTo, ArrayList<String> listeEmailCC, ArrayList<File> listePieceJointe, String jsp, HashMap<Object, Object> parametersMap)
+	@SuppressWarnings("deprecation")
+  public static void sendMail(String subject, String content, String emailFrom, String emailTo, ArrayList<String> listeEmailCC, ArrayList<File> listePieceJointe, String jsp, HashMap<Object, Object> parametersMap)
 			throws javax.mail.MessagingException {
 
 		MailMessage mail = new MailMessage("Département de Loire Atlantique");
@@ -288,8 +289,7 @@ public final class MailUtils {
 		
 
 		if(Util.notEmpty(content)) {
-
-		  mail.setContentText(content);
+		  mail.setContentText(Util.html2Ascii(content));
 		}else if(Util.notEmpty(jsp)) {
 			mail.setContentHtmlFromJsp(jsp, channel.getDefaultAdmin(), "fr", parametersMap, null);
 		}


### PR DESCRIPTION
Les retours chariots "\r\n" ou "\n" ne sont pas bien interprétés par Outlook.
Je repasse sur le fonctionnement précédent, à savoir génération des saut de ligne en HTML puis conversion via méthode utilitaire Jalios.
Attention, la méthode en question est dépréciée, mais je voudrais voir si ça fonctionne.
On rétabli en fait le fonctionnement de l'ancien site.