### PR TITLE
Fix sur le "IgnoreQueryFilter"

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/queryfilter/IgnoreQueryFilter.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/queryfilter/IgnoreQueryFilter.java
@@ -20,10 +20,12 @@ public class IgnoreQueryFilter extends LuceneQueryFilter {
   @Override
   public QueryHandler doFilterQuery(QueryHandler qh, Map context, HttpServletRequest request) {	
     Channel channel = Channel.getChannel();
-    Boolean isInFrontOffice = channel.getCurrentJcmsContext().isInFrontOffice();
-    Category ignoreCat = channel.getCategory("$jcmsplugin.socle.recherche.nonrepertoriee.cat");
-    if(isInFrontOffice && Util.notEmpty(ignoreCat)) {
-      qh.setCidsOff(ignoreCat.getId());
+    if(Util.notEmpty(channel.getCurrentJcmsContext())) {
+      Boolean isInFrontOffice = channel.getCurrentJcmsContext().isInFrontOffice();
+      Category ignoreCat = channel.getCategory("$jcmsplugin.socle.recherche.nonrepertoriee.cat");
+      if(isInFrontOffice && Util.notEmpty(ignoreCat)) {
+        qh.setCidsOff(ignoreCat.getId());
+      }
     }
     return qh;
   }


### PR DESCRIPTION
Rajout d'un test car le "context" est null lors d'un appel à l'Open Api, viales URLs de type "/rest/search"