### PR TITLE
Ajout de l'attribut de réécriture d'url pour tester le js

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -38,7 +38,9 @@ jcmsplugin.socle.recherche.geojson.communes.url: URL du geojson des communes
 jcmsplugin.socle.recherche.geojson.epci.url: URL du geojson des epci
 jcmsplugin.socle.recherche.geojson.canton.url: URL du geojson des cantons
 jcmsplugin.socle.recherche.geojson.delegation.url: URL du geojson des délégations
+# TODO obsolete à remplacer dans les jsp par data-seo-url dès que le dev sera finalisé
 jcmsplugin.socle.url-rewriting.disabled: Désactive la réécriture d'URL (true | false) ?
+jcmsplugin.socle.url-rewriting: Activer la réécriture d'URL (true | false) ?
 jcmsplugin.socle.page-utile.disabled: Désactive le composant "Page utile" (true | false) ?
 jcmsplugin.socle.idpub.annuaire.elus: ID Jalios de la publication "Annuaire des élu-e-s"
 jcmsplugin.socle.alertpri.id: ID Jalios de la portlet RI "Alertes"

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -17,7 +17,9 @@ $jcmsplugin.socle.cat.animationSportive.id: p2_108385
 
 channel.security.authorized-redirect.suivi-demande: ^https?://demarche.loire-atlantique.fr/.*
 
+# TODO obsolete à remplacer dans les jsp par data-seo-url dès que le dev sera finalisé
 jcmsplugin.socle.url-rewriting.disabled:true
+jcmsplugin.socle.url-rewriting: false
 jcmsplugin.socle.page-utile.disabled:false
 
 jcmsplugin.socle.rgpd.modale.titre: Gestion de vos préférences sur les cookies

--- a/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
@@ -51,7 +51,7 @@
 			</div>
 		</jalios:if>
 		
-		<form data-is-ajax='<%= isInRechercheFacette ? "true" : "false" %>' data-auto-load='<%= isInRechercheFacette ? "true" : "false" %>' action='<%= isInRechercheFacette ? "plugins/SoclePlugin/jsp/facettes/displayResultDecodeParams.jsp" : channel.getPublication("$jcmsplugin.socle.recherche.facettes.portal").getDisplayUrl(userLocale) %>'>
+		<form data-seo-url='<%= channel.getProperty("jcmsplugin.socle.url-rewriting")%>' data-is-ajax='<%= isInRechercheFacette ? "true" : "false" %>' data-auto-load='<%= isInRechercheFacette ? "true" : "false" %>' action='<%= isInRechercheFacette ? "plugins/SoclePlugin/jsp/facettes/displayResultDecodeParams.jsp" : channel.getPublication("$jcmsplugin.socle.recherche.facettes.portal").getDisplayUrl(userLocale) %>'>
 		    <jalios:if predicate='<%= !isInRechercheFacette %>'>
 			  <p class="ds44-textLegend ds44-textLegend--mentions txtcenter"><%= glp("jcmsplugin.socle.facette.champs-obligatoires") %></p>
 			</jalios:if>


### PR DESCRIPTION
Ajout de la réécriture d'url pour permettre à Xavier de tester et de finir son JS sur le sujet. Par défaut la réécriture est à false. L'ancien paramètre "jcmsplugin.socle.url-rewriting.disabled"  et le nouveau "jcmsplugin.socle.url-rewriting" cohabitent tant que le développement n'est pas finalisé.