### PR TITLE
1021 - màj accessibilité wysiwyg

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/policyfilter/WysiwygPolicyFilter.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/policyfilter/WysiwygPolicyFilter.java
@@ -36,6 +36,7 @@ public class WysiwygPolicyFilter extends BasicWysiwygPolicyFilter {
 	  formattedText = deleteEmptyTitle(text);
 	  formattedText = deleteEmptyAriaLabelse(text);
 	  formattedText = removeDoubleBr(text);
+	  formattedText = removeUselessSpacesLink(text);
 	  return formattedText;
 	}
 	
@@ -100,6 +101,17 @@ public class WysiwygPolicyFilter extends BasicWysiwygPolicyFilter {
     while (txtClone.indexOf(doubleBr) >= 0) {
       txtClone = txtClone.replaceAll(doubleBr, "<br>");
     }
+    return txtClone;
+  }
+  
+  /**
+   * Retire les espaces en trop au début et à la fin des tags <a>
+   * @param text
+   * @return
+   */
+  private String removeUselessSpacesLink(String text) {
+    String txtClone = text.replaceAll(" *(?=(<\\/a>))", "</a>").replaceAll("(&nbsp;)*(?=(<\\/a>))", "</a>"); // espaces à la fin
+    txtClone = text.replaceAll("(?<=(<a [^>]+>)) *", "").replaceAll("(?<=(<a [^>]+>))(&nbsp;)*", ""); // espaces au début
     return txtClone;
   }
 

--- a/WEB-INF/classes/fr/cg44/plugin/socle/policyfilter/WysiwygPolicyFilter.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/policyfilter/WysiwygPolicyFilter.java
@@ -31,6 +31,11 @@ public class WysiwygPolicyFilter extends BasicWysiwygPolicyFilter {
 	private String generateNewRenderedWysiwyg(String text, Locale userLocale) {
 	  String formattedText = checkExternalLinks(text, userLocale);
 	  formattedText = removeParagraphsAroundLinks(text);
+	  formattedText = removeEmptyParagraphs(text);
+	  formattedText = removeDoubleSpaces(text);
+	  formattedText = deleteEmptyTitle(text);
+	  formattedText = deleteEmptyAriaLabelse(text);
+	  formattedText = removeDoubleBr(text);
 	  return formattedText;
 	}
 	
@@ -41,6 +46,61 @@ public class WysiwygPolicyFilter extends BasicWysiwygPolicyFilter {
 	 */
 	private String removeParagraphsAroundLinks(String text) {
     return text.replaceAll("<p><a", "<a").replaceAll("</a></p>", "</a>");
+  }
+	
+	/**
+	 * Retire les balises <p> vides
+	 * @param text
+	 * @return
+	 */
+	private String removeEmptyParagraphs(String text) {
+	  return text.replaceAll("<p>&nbsp;</p>", "");
+	}
+	
+	/**
+	 * Retire tous les doubles &nbsp; jusqu'à ce qu'il n'y en ait plus
+	 * @param text
+	 * @return
+	 */
+	private String removeDoubleSpaces(String text) {
+	  String doubleSpace = "&nbsp;&nbsp;";
+	  String txtClone = text;
+	  while (txtClone.indexOf(doubleSpace) >= 0) {
+	    txtClone = txtClone.replaceAll(doubleSpace, "&nbsp;");
+	  }
+	  return txtClone;
+	}
+	
+	/**
+	 * Retire les attributs title vides
+	 * @param text
+	 * @return
+	 */
+	private String deleteEmptyTitle(String text) {
+	  return text.replaceAll("title=\"\"", "");
+	}
+	
+	/**
+   * Retire les attributs aria-label vides
+   * @param text
+   * @return
+   */
+  private String deleteEmptyAriaLabelse(String text) {
+    return text.replaceAll("aria-label=\"\"", "");
+  }
+  
+  /**
+   * Retire tous les doubles <br> jusqu'à ce qu'il n'y en ait plus
+   * @param text
+   * @return
+   */
+  private String removeDoubleBr(String text) {
+    String doubleBr = "<br><br>";
+    String txtClone = text;
+    while (txtClone.indexOf(doubleBr) >= 0) {
+      txtClone = txtClone.replaceAll(doubleBr, "<br>");
+    }
+    return txtClone;
   }
 
   /**


### PR DESCRIPTION
supprimer les <p> vides de type <p>&nbsp;</p>
supprimer les&nbsp;&nbsp;multiples pour n'en garder qu'un seul
supprimer les title=""
supprimer les aria-label=""
supprimer les doubles<br> de type <br><br> et les remplacer par <br>