### PR TITLE
FIx : optimisation SEO (RS-1581)

### DIFF
--- a/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
@@ -8,6 +8,11 @@
 	PortletRechercheFacettes obj = (PortletRechercheFacettes)portlet;
 
     isInRechercheFacette = isInRechercheFacette || obj.getAfficherResultatDansLannuaire();
+    
+    // SEO : bloque l'indexation des pages de résultats
+    if(isInRechercheFacette){
+      request.setAttribute("noindex", true);
+    }
 	
 	String query = Util.notEmpty(obj.getQueries()) ? obj.getQueries()[0] : "";
 	request.setAttribute("query", query);

--- a/plugins/SoclePlugin/types/PortletSearch/query.jsp
+++ b/plugins/SoclePlugin/types/PortletSearch/query.jsp
@@ -3,6 +3,9 @@
 %><%@ include file='/jcore/doHeader.jspf' %>
 <%
 String formUid = ServletUtil.generateUniqueDOMId(request, "uid");
+
+// SEO : bloque l'indexation des pages de résultats
+request.setAttribute("noindex", true);
 %>
 <main role="main" id="content">
 


### PR DESCRIPTION
Ajout d'un attribut récupéré par le module SEO.
Permet de générer un meta robot en "noindex, nofollow" en cas de besoin.
Ici : pour les pages de résultats de recherche (moteur général + recherche facette).