### PR TITLE
FIX RS-1580 erreurs verif html

### DIFF
--- a/plugins/SoclePlugin/jsp/portal/calculetteOA.jsp
+++ b/plugins/SoclePlugin/jsp/portal/calculetteOA.jsp
@@ -16,7 +16,7 @@
 			                    <div class="ds44-form__container">
 			                        <div class="ds44-posRel">
 			                            <label for="ds44-js-soa-template-field-1" class="ds44-formLabel"><span class="ds44-labelTypePlaceholder"><span><%= glp("jcmsplugin.socle.calculetteOA.revenubrut.label") %><sup aria-hidden="true">*</sup></span></span></label>
- 			                            <input type="text" id="ds44-js-soa-template-field-1" name="ds44-js-soa-template-field-1" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.calculetteOA.revenubrut.title") %>" inputmode="numeric" pattern="[0-9]*" required   aria-describedby="explanation-ds44-js-soa-template-field-1" /><button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.socle.calculetteOA.revenubrut.label")) %></span></button>
+ 			                            <input type="text" id="ds44-js-soa-template-field-1" name="ds44-js-soa-template-field-1" class="ds44-inpStd" title='<%= HttpUtil.encodeForHTMLAttribute(glp("jcmsplugin.socle.calculetteOA.revenubrut.title")) %>' inputmode="numeric" pattern="[0-9]*" required   aria-describedby="explanation-ds44-js-soa-template-field-1" /><button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.socle.calculetteOA.revenubrut.label")) %></span></button>
 			                        </div>
 			
 			                        <div class="ds44-field-information" aria-live="polite">

--- a/plugins/SoclePlugin/jsp/portal/socialNetworksFooter.jspf
+++ b/plugins/SoclePlugin/jsp/portal/socialNetworksFooter.jspf
@@ -1,5 +1,5 @@
 <%@ include file="socialNetworksCommon.jspf" %> 
-<p role="heading" aria-level="2" class="h4-like mbs txtcenter" id="idTitreFooter2"><%=glp("jcmsplugin.socle.social-networks-follow.label") %></p>
+<p role="heading" aria-level="2" class="h4-like mbs txtcenter" id='<%= ServletUtil.generateUniqueDOMId(request, "idTitreFooter")%>'><%=glp("jcmsplugin.socle.social-networks-follow.label") %></p>
 <ul class="ds44-list ds44-flex-container ds44-flex-align-center">
 <%
 for(int i=0; i<socialNetworksLabelsList.size(); i++){%>

--- a/plugins/SoclePlugin/types/PortletAgendaInfolocale/doPortletAgendaInfolocaleFacettes.jsp
+++ b/plugins/SoclePlugin/types/PortletAgendaInfolocale/doPortletAgendaInfolocaleFacettes.jsp
@@ -106,7 +106,7 @@
 	      <div class="ds44-js-results-container">
 	         <div class="ds44-js-results-card" data-url="plugins/SoclePlugin/jsp/facettes/displayPub.jsp" aria-hidden="true"></div>
 	         <div class="ds44-js-results-list" data-display-mode='<%= true ? "external" : "inline" %>'>
-	            <p aria-level="2" rôle="heading" id="ds44-results-new-search" class="h3-like mbs txtcenter center ds44--3xl-padding-t ds44--3xl-padding-b">
+	            <p aria-level="2" role="heading" id="ds44-results-new-search" class="h3-like mbs txtcenter center ds44--3xl-padding-t ds44--3xl-padding-b">
 	               <span aria-level="2" role="heading"><%= glp("jcmsplugin.socle.faire.recherche") %></span>
 	            </p>
 	         </div>

--- a/plugins/SoclePlugin/types/PortletFacetteAgendaDate/doPortletFacetteAgendaDateBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletFacetteAgendaDate/doPortletFacetteAgendaDateBoxDisplay.jsp
@@ -1,10 +1,10 @@
 <%@page import="fr.cg44.plugin.socle.infolocale.util.InfolocaleUtil"%>
 <%@page import="fr.cg44.plugin.socle.SocleUtils"%>
-<%@ page contentType="text/html; charset=UTF-8" %>
-<%@ include file='/jcore/doInitPage.jspf' %>
-<%@ include file='/jcore/portal/doPortletParams.jspf' %>
-<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf' %>
-<%@ taglib prefix="ds" tagdir="/WEB-INF/tags" %>
+<%@ page contentType="text/html; charset=UTF-8"%>
+<%@ include file='/jcore/doInitPage.jspf'%>
+<%@ include file='/jcore/portal/doPortletParams.jspf'%>
+<%@ include file='/plugins/SoclePlugin/jsp/facettes/commonParamsFacettes.jspf'%>
+<%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <% PortletFacetteAgendaDate obj = (PortletFacetteAgendaDate)portlet; %>
 
 <% 
@@ -19,80 +19,157 @@ boolean isRequired = obj.getFacetteObligatoire();
 %>
 
 <div class="ds44-form__container">
-   <div class='ds44-select__shape <%= isInRechercheFacette ? "ds44-inpStd" : "ds44-inpLarge" %>'>
-      <p id="label-<%= uid %>" class="ds44-selectLabel" aria-hidden="true"><%= title %><sup aria-hidden="true"><%= isRequired ? glp("jcmsplugin.socle.facette.asterisque") : "" %></sup></p>
-      <div id="<%= uid %>" data-name="agenda-date" class="ds44-js-select-radio ds44-selectDisplay"  data-required="<%= isRequired %>"></div>
-      <button class="ds44-reset" type="button" aria-describedby="label-<%= uid %>"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", title) %></span></button>
-      <button type="button" id="button-<%= uid %>" class="ds44-btnIco ds44-posAbs ds44-posRi ds44-btnOpen" aria-expanded="false" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", title) : title %>'><i class="icon icon-down icon--sizeL" aria-hidden="true"></i><span id="button-message-<%= uid %>" class="visually-hidden"><%= title %></span></button>
-   </div>
-   
-   <div class="ds44-select-container hidden">
-        <div class="ds44-listSelect">
-            <ul class="ds44-list" id="listbox-<%= uid %>">
-                <jalios:foreach name="itDateLabel" type="String" collection="<%= datesLabelValues.keySet() %>">
-	                <li class="ds44-select-list_elem">
-		               <div class="ds44-form__container ds44-checkBox-radio_list">
-		                  <% 
-		                  String uidFormElem = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
-		                  %>
-		                  <input type="radio" name="form-element-<%= uid %>" value="<%= datesLabelValues.get(itDateLabel) %>" id="name-radio-<%= uidFormElem %>-<%= itCounter %>" class="ds44-radio" /><label id="label-radio-<%= uidFormElem %>-<%= itCounter %>" for="name-radio-<%= uidFormElem %>-<%= itCounter %>" class="ds44-radioLabel"><%= itDateLabel %></label>
-		               </div>
-		            </li>
-	            </jalios:foreach>
-	            <li class="ds44-select-list_elem">
-	               <%-- Sélecteur de plage de dates --%>
-	               <% 
-	                  String uidFormElem = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
-	                      
-	                  String uidFormElemDateDebut = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
-	                  
-	                  String uidFormElemDateFin = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
-	                  
-	                  int indexCheckbox = datesLabelValues.size() + 1;
-	               %>
-	               <div class="ds44-form__container ds44-checkBox-radio_list ">
-	                   <input type="radio" name="form-element-<%= uid %>" value="<%= indexCheckbox %>" id="name-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %>" class="ds44-radio"><label id="label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %>" for="name-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %>" class="ds44-radioLabel"><%= glp("jcmsplugin.socle.facette.date.select.example.custom") %></label>
-	               </div>
-	               <div class="ds44-select-list_elem_child hidden">
-			         <div class="ds44-form__container">
-			            <div class="ds44-posRel">
-			               <label for="form-element-<%= uidFormElemDateDebut %>" class="ds44-formLabel ds44-datepicker"><span class="ds44-labelTypePlaceholder"><span><%= glp("jcmsplugin.socle.facette.date.select.du.label") %><sup aria-hidden="true"><%= isRequired ? glp("jcmsplugin.socle.facette.asterisque") : "" %></sup></span></span></label>
-			               <input class="ds44-input-value" type="hidden">
-			               <div data-name="form-element-<%= uidFormElemDateDebut %>" class="ds44-datepicker__shape ds44-inpStd" data-past-dates="false" data-required="<%= isRequired %>">
-			                 <input id="form-element-<%= uidFormElemDateDebut %>" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.jour", glp("jcmsplugin.socle.facette.date.select.du.label"))) : glp("jcmsplugin.socle.facette.date.exemple.jour", glp("jcmsplugin.socle.facette.date.select.du.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>"><span>/</span><input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.mois", glp("jcmsplugin.socle.facette.date.select.du.label"))) : glp("jcmsplugin.socle.facette.date.exemple.mois", glp("jcmsplugin.socle.facette.date.select.du.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>"><span>/</span><input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="4" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.du.label"))) : glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.du.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateDebut %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>">
-			               </div>
-			               <button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.socle.facette.date.select.du.label")) %></span></button>
-			               <span class="ds44-calendar" aria-hidden="true" aria-describedby="label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %>"><i class="icon icon-date icon--large" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.date.calendrier.afficher", glp("jcmsplugin.socle.facette.date.select.du.label")) %></span></span>
-			               <div class="vanilla-calendar hidden" data-calendar-past-dates="false"></div>
-			            </div>
-			            <div class="ds44-field-information" aria-live="polite">
-			               <ul class="ds44-field-information-list ds44-list">
-			                  <li id="explanation-form-element-<%= uidFormElemDateDebut %>" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.facette.date.select.example.label") %></li>
-			               </ul>
-			            </div>
-			         </div>
-			         <div class="ds44-form__container ds44-mt2">
-			            <div class="ds44-posRel">
-			               <label for="form-element-<%= uidFormElemDateFin %>" class="ds44-formLabel ds44-datepicker"><span class="ds44-labelTypePlaceholder"><span>Jusqu'au</span></span></label>
-			               <input class="ds44-input-value" type="hidden">
-			               <div data-name="form-element-<%= uidFormElemDateFin %>" class="ds44-datepicker__shape ds44-inpStd" data-next-year-dates="false" data-previous-date-id="form-element-<%= uidFormElemDateDebut %>">
-			                 <input id="form-element-<%= uidFormElemDateFin %>" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.jour", glp("jcmsplugin.socle.facette.date.select.jusquau.label"))) : glp("jcmsplugin.socle.facette.date.exemple.jour", glp("jcmsplugin.socle.facette.date.select.jusquau.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>"><span>/</span><input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.mois", glp("jcmsplugin.socle.facette.date.select.jusquau.label"))) : glp("jcmsplugin.socle.facette.date.exemple.mois", glp("jcmsplugin.socle.facette.date.select.jusquau.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>"><span>/</span><input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="4" title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.jusquau.label"))) : glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.jusquau.label")) %>' data-is-date="true" required="" aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>" data-bkp-aria-describedby="explanation-form-element-<%= uidFormElemDateFin %> label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %> button-message-form-element-<%= uid %>">
-			               </div>
-			               <button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden">Effacer le contenu saisi dans le champ : Jusqu'au</span></button>
-			               <span class="ds44-calendar" aria-hidden="true" aria-describedby="label-radio-form-element-<%= uidFormElem %>-<%= indexCheckbox %>"><i class="icon icon-date icon--large" aria-hidden="true"></i><span class="visually-hidden">Afficher le calendrier pour le champ : Jusqu'au</span></span>
-			               <div class="vanilla-calendar hidden" data-calendar-next-year-dates="false"></div>
-			            </div>
-			            <div class="ds44-field-information" aria-live="polite">
-			               <ul class="ds44-field-information-list ds44-list">
-			                  <li id="explanation-form-element-<%= uidFormElemDateFin %>" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.facette.date.select.example.label") %></li>
-			               </ul>
-			            </div>
-			         </div>
-			      </div>
-	            </li>
-            </ul>
-        </div>
-        <button type="button" class="ds44-fullWBtn ds44-btnSelect ds44-theme" title='<%= glp("jcmsplugin.socle.facette.cat-lie.valider-selection.label", title) %>'><span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.valider") %></span><i class="icon icon-long-arrow-right ds44-noLineH" aria-hidden="true"></i></button>
-   </div>
-   
+	<div class='ds44-select__shape <%= isInRechercheFacette ? "ds44-inpStd" : "ds44-inpLarge" %>'>
+		<p id="label-<%= uid %>" class="ds44-selectLabel" aria-hidden="true">
+			<%= title %><sup aria-hidden="true"><%= isRequired ? glp("jcmsplugin.socle.facette.asterisque") : "" %></sup>
+		</p>
+		<div id="<%= uid %>" data-name="agenda-date" class="ds44-js-select-radio ds44-selectDisplay" data-required="<%= isRequired %>"></div>
+		<button class="ds44-reset" type="button" aria-describedby="label-<%= uid %>">
+			<i class="icon icon-cross icon--sizeL" aria-hidden="true"></i>
+			<span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", title) %></span>
+		</button>
+		<button type="button" id="button-<%= uid %>" class="ds44-btnIco ds44-posAbs ds44-posRi ds44-btnOpen" aria-expanded="false"
+				title='<%= isRequired ? glp("jcmsplugin.socle.facette.champ-obligatoire.title", title) : title %>'>
+			<i class="icon icon-down icon--sizeL" aria-hidden="true"></i>
+			<span id="button-message-<%= uid %>" class="visually-hidden"><%= title %></span>
+		</button>
+	</div>
+
+	<div class="ds44-select-container hidden">
+		<div class="ds44-listSelect">
+			<ul class="ds44-list" id="listbox-<%= uid %>">
+				<jalios:foreach name="itDateLabel" type="String" collection="<%= datesLabelValues.keySet() %>">
+					<li class="ds44-select-list_elem">
+						<div class="ds44-form__container ds44-checkBox-radio_list">
+							<% String uidFormElem = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element")); %>
+							<input type="radio" name="<%= uid %>" value="<%= datesLabelValues.get(itDateLabel) %>"
+									id="name-radio-<%= uidFormElem %>-<%= itCounter %>" class="ds44-radio" />
+							<label id="label-radio-<%= uidFormElem %>-<%= itCounter %>"
+									for="name-radio-<%= uidFormElem %>-<%= itCounter %>" class="ds44-radioLabel">
+								<%= itDateLabel %>
+							</label>
+						</div>
+					</li>
+				</jalios:foreach>
+				<li class="ds44-select-list_elem">
+					<%-- Sélecteur de plage de dates --%>
+					<% 
+						String uidFormElem = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
+
+						String uidFormElemDateDebut = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
+
+						String uidFormElemDateFin = ServletUtil.generateUniqueDOMId(request, glp("jcmsplugin.socle.facette.form-element"));
+
+						int indexCheckbox = datesLabelValues.size() + 1;
+					%>
+					<div class="ds44-form__container ds44-checkBox-radio_list ">
+						<input type="radio" name="<%= uid %>" value="<%= indexCheckbox %>" id="name-radio-<%= uidFormElem %>-<%= indexCheckbox %>" class="ds44-radio"/>
+						<label id="label-radio-<%= uidFormElem %>-<%= indexCheckbox %>" for="name-radio-<%= uidFormElem %>-<%= indexCheckbox %>" class="ds44-radioLabel">
+							<%= glp("jcmsplugin.socle.facette.date.select.example.custom") %>
+						</label>
+					</div>
+					<div class="ds44-select-list_elem_child hidden">
+						<div class="ds44-form__container">
+							<div class="ds44-posRel">
+								<label for="<%= uidFormElemDateDebut %>" class="ds44-formLabel ds44-datepicker">
+									<span class="ds44-labelTypePlaceholder">
+										<span>
+											<%= glp("jcmsplugin.socle.facette.date.select.du.label") %>
+											<sup aria-hidden="true"><%= isRequired ? glp("jcmsplugin.socle.facette.asterisque") : "" %></sup>
+										</span>
+									</span>
+								</label> 
+								<input class="ds44-input-value" type="hidden"/>
+								<div data-name="<%= uidFormElemDateDebut %>" class="ds44-datepicker__shape ds44-inpStd" data-past-dates="false" data-required="<%= isRequired %>">
+									<%
+										String titleInputFromDay   = glp("jcmsplugin.socle.facette.date.exemple.jour",  glp("jcmsplugin.socle.facette.date.select.du.label"));
+										String titleInputFromMonth = glp("jcmsplugin.socle.facette.date.exemple.mois",  glp("jcmsplugin.socle.facette.date.select.du.label"));
+										String titleInputFromYear  = glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.du.label"));
+										if(isRequired) {
+											titleInputFromDay   = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputFromDay);
+											titleInputFromMonth = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputFromMonth);
+											titleInputFromYear  = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputFromYear);
+										}
+										String attributeDescribedByInputFrom = "explanation-" + uidFormElemDateDebut + " label-radio-" + uidFormElem + "-" + indexCheckbox + " button-message-" + uid;
+									%>
+									<input id="<%= uidFormElemDateDebut %>" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputFromDay) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputFrom %>' data-bkp-aria-describedby='<%= attributeDescribedByInputFrom %>' />
+									<span>/</span>
+									<input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputFromMonth) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputFrom %>' data-bkp-aria-describedby='<%= attributeDescribedByInputFrom %>' />
+									<span>/</span>
+									<input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="4" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputFromYear) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputFrom %>' data-bkp-aria-describedby='<%= attributeDescribedByInputFrom %>' />
+								</div>
+								<button class="ds44-reset" type="button">
+									<i class="icon icon-cross icon--sizeL" aria-hidden="true"></i>
+									<span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.socle.facette.date.select.du.label")) %></span>
+								</button>
+								<span class="ds44-calendar" aria-hidden="true" aria-describedby="label-radio-<%= uidFormElem %>-<%= indexCheckbox %>">
+									<i class="icon icon-date icon--large" aria-hidden="true"></i>
+									<span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.date.calendrier.afficher", glp("jcmsplugin.socle.facette.date.select.du.label")) %></span>
+								</span>
+								<div class="vanilla-calendar hidden" data-calendar-past-dates="false"></div>
+							</div>
+							<div class="ds44-field-information" aria-live="polite">
+								<ul class="ds44-field-information-list ds44-list">
+									<li id="explanation-<%= uidFormElemDateDebut %>" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.facette.date.select.example.label") %></li>
+								</ul>
+							</div>
+						</div>
+						<div class="ds44-form__container ds44-mt2">
+							<div class="ds44-posRel">
+								<label for="<%= uidFormElemDateFin %>" class="ds44-formLabel ds44-datepicker">
+									<span class="ds44-labelTypePlaceholder">
+										<span>Jusqu'au</span>
+									</span>
+								</label>
+								<input class="ds44-input-value" type="hidden">
+								<div data-name="<%= uidFormElemDateFin %>" class="ds44-datepicker__shape ds44-inpStd" data-next-year-dates="false" data-previous-date-id="<%= uidFormElemDateDebut %>">
+									<%
+										String titleInputToDay   = glp("jcmsplugin.socle.facette.date.exemple.jour",  glp("jcmsplugin.socle.facette.date.select.jusquau.label"));
+										String titleInputToMonth = glp("jcmsplugin.socle.facette.date.exemple.mois",  glp("jcmsplugin.socle.facette.date.select.jusquau.label"));
+										String titleInputToYear  = glp("jcmsplugin.socle.facette.date.exemple.annee", glp("jcmsplugin.socle.facette.date.select.jusquau.label"));
+										if(isRequired) {
+											titleInputToDay   = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputToDay);
+											titleInputToMonth = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputToMonth);
+											titleInputToYear  = glp("jcmsplugin.socle.facette.champ-obligatoire.title", titleInputToYear);
+										}
+										String attributeDescribedByInputTo = "explanation-" + uidFormElemDateFin + " label-radio-" + uidFormElem + "-" + indexCheckbox + " button-message-" + uid;
+									%>									
+									<input id="<%= uidFormElemDateDebut %>" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputToDay) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputTo %>' data-bkp-aria-describedby='<%= attributeDescribedByInputTo %>' />
+									<span>/</span>
+									<input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="2" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputToMonth) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputTo %>' data-bkp-aria-describedby='<%= attributeDescribedByInputTo %>' />
+									<span>/</span>
+									<input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="4" title='<%= HttpUtil.encodeForHTMLAttribute(titleInputToYear) %>'
+											data-is-date="true" required="" aria-describedby='<%= attributeDescribedByInputTo %>' data-bkp-aria-describedby='<%= attributeDescribedByInputTo %>' />
+								</div>
+								<button class="ds44-reset" type="button">
+									<i class="icon icon-cross icon--sizeL" aria-hidden="true"></i>
+									<span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.socle.facette.date.select.jusquau.label")) %></span>
+								</button>
+								<span class="ds44-calendar" aria-hidden="true" aria-describedby="label-radio-<%= uidFormElem %>-<%= indexCheckbox %>">
+									<i class="icon icon-date icon--large" aria-hidden="true"></i>
+									<span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.date.calendrier.afficher", glp("jcmsplugin.socle.facette.date.select.jusquau.label")) %></span>
+								</span>
+								<div class="vanilla-calendar hidden" data-calendar-next-year-dates="false"></div>
+							</div>
+							<div class="ds44-field-information" aria-live="polite">
+								<ul class="ds44-field-information-list ds44-list">
+									<li id="explanation-<%= uidFormElemDateFin %>" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.facette.date.select.example.label") %></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</li>
+			</ul>
+		</div>
+		<button type="button" class="ds44-fullWBtn ds44-btnSelect ds44-theme" title='<%= glp("jcmsplugin.socle.facette.cat-lie.valider-selection.label", title) %>'>
+			<span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.valider") %></span>
+			<i class="icon icon-long-arrow-right ds44-noLineH" aria-hidden="true"></i>
+		</button>
+	</div>
+
 </div>

--- a/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesBoxDisplay.jsp
@@ -194,7 +194,7 @@
 	          <div class="ds44-js-results-container">
 	              <div class="ds44-js-results-card" data-url="plugins/SoclePlugin/jsp/facettes/displayPub.jsp" aria-hidden="true"></div>
 	              <div class="ds44-js-results-list" data-display-mode='<%= obj.getModeDaffichageDuContenu() ? "external" : "inline" %>'>
-	                  <p aria-level="2" rôle="heading" id="ds44-results-new-search" class="h3-like mbs txtcenter center ds44--3xl-padding-t ds44--3xl-padding-b">
+	                  <p aria-level="2" role="heading" id="ds44-results-new-search" class="h3-like mbs txtcenter center ds44--3xl-padding-t ds44--3xl-padding-b">
 	                    <span aria-level="2" role="heading"><%= glp("jcmsplugin.socle.faire.recherche") %></span>
 	                  </p>            
 	              </div>


### PR DESCRIPTION
https://refonte44.atlassian.net/browse/RS-1580

Pour `doPortletFacetteAgendaDateBoxDisplay.jsp`, il y a beaucoup de modif qui sont juste des rajouts à la ligne et de l'indentation. Y a peut-être moyen d'y voir plus clair en cachant les "whitespace changes". 
Je devai juste corriger les title des inputs des jours/mois/années de début et de fin de période ; mais les erreurs étaient sur des lignes _très_ longues (La plus longue ligne faisait 2387 caractères !). Ces modifs sont lignes 84 à 102 et lignes 129 à 147.
J'ai aussi mis des `glp()` à la place de textes laissés en dur ligne 151 et 155 ; et j'ai viré tous les "form-element" qui étaient en double dans les id.

> Dans la vérification HTML, il reste une erreur dans une balise script. Suite à ma discussion avec Stéphane, j'attends que Franck me dise s'il on peut ne pas avoir la à fix. Si il me répond oui, alors je pourrai merger direct, sinon il restera du dev à faire...

Franck m'a dit que c'était bon finalement.