### PR TITLE
1500 - retirer contenu "alt" tuiles sans figcaption

### DIFF
--- a/WEB-INF/tags/tuileContenuEnAvant.tag
+++ b/WEB-INF/tags/tuileContenuEnAvant.tag
@@ -15,9 +15,6 @@
 <%@ attribute name="customUrl" required="false" fragment="false"
     rtexprvalue="true" type="String"
     description="URL custom pour le lien"%>  
-<%@ attribute name="customAlt" required="false" fragment="false"
-    rtexprvalue="true" type="String"
-    description="Texte alternatif custom pour le lien"%>  
 <%@ attribute name="isExterne" required="false" fragment="false"
     rtexprvalue="true" type="Boolean"
     description="Détermine si le lien est externe"%>
@@ -90,17 +87,6 @@
     String titleUrl = "";
     
     String alt="";
-    
-    if(Util.notEmpty(customAlt)) {
-    	titleUrl = customAlt;
-    	alt = customAlt;
-    	if(displayTargetBlank) titleUrl = JcmsUtil.glp(userLang, "jcmsplugin.socle.lien.nouvelonglet", titleUrl);
-    } else {
-      try {
-        alt = ((String) pub.getFieldValue("texteAlternatif"));
-        if (Util.isEmpty(alt)) alt = "";
-      } catch(Exception e) {}
-    }
     
 %>
 <% if (!Boolean.parseBoolean(isUnique)) { %>

--- a/plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
@@ -37,13 +37,6 @@ if (Util.isEmpty(urlImage)) {
      urlImage = SocleUtils.getUrlOfFormattedImageCarree(urlImage);
  }
  
- String altText = "";
-
- try {
-   altText = ((String) pub.getFieldValue("texteAlternatif"));
- } catch(Exception e) {}
- if (Util.isEmpty(altText)) altText = "";
- String altImage = (pub.getTitle().equalsIgnoreCase(altText)) ? "" : altText;
 %>
 
 <section class="ds44-card ds44-js-card ds44-card--horizontal <%=styleContext%> <%= isSmall ? "ds44-tiny-reducedFont" : ""%>">
@@ -51,7 +44,7 @@ if (Util.isEmpty(urlImage)) {
         <jalios:if predicate="<%= Util.notEmpty(urlImage) %>">
             <div class="ds44-card__section--horizontal--img<%= isSmall ? "--dim110" : "" %>">
                 <picture class="ds44-container-imgRatio ds44-container-imgRatio--carre">
-                    <img class="ds44-imgRatio" src="<%= urlImage %>" alt='<%= altImage %>'>
+                    <img class="ds44-imgRatio" src="<%= urlImage %>" alt=''>
                 </picture>
             </div>
         </jalios:if>

--- a/plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
@@ -26,12 +26,7 @@ try {
     location = (String) pub.getFieldValue("lieu");
 } catch(Exception e) {}
 
-String imageAlt = "-1";
-
-try {
-	imageAlt = ((String) pub.getFieldValue("texteAlternatif"));
-} catch(Exception e) {}
-if (Util.isEmpty(imageAlt)) imageAlt = "-1"; // dans figurePicture, si la valeur de "alt" est à -1 on force le champ alt vide (autrement, il ira chercher un alt dans le contenu)
+String imageAlt = "-1"; // dans figurePicture, si la valeur de "alt" est à -1 on force le champ alt vide (autrement, il ira chercher un alt dans le contenu)
 %>
 
 <section class="ds44-card ds44-js-card ds44-card--verticalPicture <%=styleContext%>">

--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
@@ -32,11 +32,10 @@
 	                   <%
 	                   Lien itLien = (Lien) itContenuEnAvant;
 	                   String customUrl = SocleUtils.getUrlPubFromLien(itLien);
-	                   String texteAlt = SocleUtils.getAltFromLien(itLien);
 	                   Boolean isExterne = SocleUtils.isLienExterne(itLien);
 	                   %>
 	                   <ds:tuileContenuEnAvant content="<%= itContenuEnAvant %>" isUnique="<%= Boolean.toString(box.getContenusEnAvant().length == 1) %>" 
-	                       positionTitre="<%= positionTitre %>" customUrl="<%= customUrl %>" customAlt="<%= texteAlt %>" isExterne="<%= isExterne %>"/>
+	                       positionTitre="<%= positionTitre %>" customUrl="<%= customUrl %>" isExterne="<%= isExterne %>"/>
 	                </jalios:if>
 	                <jalios:default>
 	                   <ds:tuileContenuEnAvant content="<%= itContenuEnAvant %>" isUnique="<%= Boolean.toString(box.getContenusEnAvant().length == 1) %>" positionTitre="<%= positionTitre %>"/>

--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselSliderSixPanels.jsp
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselSliderSixPanels.jsp
@@ -42,11 +42,10 @@ String sliderAmounts = "1";
                        <%
                        Lien itLien = (Lien) itContenuEnAvant;
                        String customUrl = SocleUtils.getUrlPubFromLien(itLien);
-                       String texteAlt = SocleUtils.getAltFromLien(itLien);
                        Boolean isExterne = SocleUtils.isLienExterne(itLien);
                        %>
                        <ds:tuileContenuEnAvant content="<%= itContenuEnAvant %>" isUnique="<%= Boolean.toString(box.getContenusEnAvant().length == 1) %>" 
-                           positionTitre="<%= positionTitre %>" customUrl="<%= customUrl %>" customAlt="<%= texteAlt %>" isExterne="<%= isExterne %>"/>
+                           positionTitre="<%= positionTitre %>" customUrl="<%= customUrl %>" isExterne="<%= isExterne %>"/>
                     </jalios:if>
                     <jalios:default>
                        <ds:tuileContenuEnAvant content="<%= itContenuEnAvant %>" isUnique="<%= Boolean.toString(box.getContenusEnAvant().length == 1) %>" positionTitre="<%= positionTitre %>"/>


### PR DESCRIPTION
Au final, malgré ce qui m'a été dit, il faut vider complètement le champ 'alt' dans tous les cas pour les images où il n'y a pas de figcaption (tuiles en avant, verticales, horizontales)