### PR TITLE
hotfix RS-1627

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -365,7 +365,7 @@ jcmsplugin.socle.ficheaide.troisieme-onglet.label: 3e onglet
 jcmsplugin.socle.ficheaide.docutils.label: Documents utiles :
 jcmsplugin.socle.ficheaide.enligne.label: En ligne :
 jcmsplugin.socle.ficheaide.fairedemandeligne.label: Faire une demande en ligne
-jcmsplugin.socle.ficheaide.fairedemandelignelink.label: Connectez-vous pour faire une demande en ligne de code de suivi
+jcmsplugin.socle.ficheaide.fairedemandelignelink.label: Connectez-vous pour faire une demande en ligne
 jcmsplugin.socle.ficheaide.nodoc.label: Aucun document disponible
 jcmsplugin.socle.ficheaide.suivre.label: Suivre une demande en cours
 jcmsplugin.socle.ficheaide.duree.label: Durée :

--- a/plugins/SoclePlugin/jsp/templates/fileDocumentEmbedTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/templates/fileDocumentEmbedTemplate.jsp
@@ -10,7 +10,7 @@ FileDocument obj = (FileDocument) data;
 
 String title = HttpUtil.encodeForHTMLAttribute(obj.getTitle());
 String fileType = FileDocument.getExtension(obj.getFilename()).toUpperCase();
-String fileSize = Util.formatFileSize(obj.getSize(), userLocale,false);
+String fileSize = Util.formatFileSize(obj.getSize());
 %>
 
 	<p class="ds44-docListElem"><i class="icon icon-file ds44-docListIco" aria-hidden="true"></i>

--- a/plugins/SoclePlugin/types/FicheActionEducative/doFicheActionEducativeFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheActionEducative/doFicheActionEducativeFullDisplay.jsp
@@ -250,7 +250,7 @@ boolean hasParcoursCollege = obj.getCategorySet().contains(channel.getCategory("
                                 // Récupérer l'extension du fichier
                                 String fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
                                 // Récupérer la taille du fichier
-                                String fileSize = Util.formatFileSize(itDoc.getSize(), userLocale);
+                                String fileSize = Util.formatFileSize(itDoc.getSize());
                                 %>
                                 <p class="ds44-docListElem"><i class="icon icon-file ds44-docListIco" aria-hidden="true"></i><a href="<%= itDoc.getDownloadUrl() %>" target="_blank" title='<%= HttpUtil.encodeForHTMLAttribute(itDoc.getTitle()) %> - <%= fileType %> - <%= HtmlUtil.html2text(fileSize) %>  <%= glp("jcmsplugin.socle.accessibily.newTabLabel") %>'><%= itDoc.getTitle() %></a><span class="ds44-cardFile"><%= fileType %> - <%= fileSize %></span></p>
                                 </li>

--- a/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheAide/doFicheAideFullDisplay.jsp
@@ -287,13 +287,13 @@
 											// Récupérer l'extension du fichier
 											String fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
 											// Récupérer la taille du fichier
-											String fileSize = Util.formatFileSize(itDoc.getSize(), userLocale);
+											String fileSize = Util.formatFileSize(itDoc.getSize());
 											
 											String fileUrl = ServletUtil.getBaseUrl(request) + itDoc.getDownloadUrl(); 
 										%>
 										<p class="ds44-docListElem">
 											<i class="icon icon-file ds44-docListIco" aria-hidden="true"></i>
-											<% String titleModalFaireDemande = itDoc.getTitle() + " - " + fileType + " - " + fileSize + " - " + glp("jcmsplugin.socle.accessibily.newTabLabel"); %>
+											<% String titleModalFaireDemande = itDoc.getTitle() + " - " + fileType + " - " + fileSize + " " + glp("jcmsplugin.socle.accessibily.newTabLabel"); %>
 											<a href="<%= itDoc.getDownloadUrl() %>" target="_blank" title='<%= HttpUtil.encodeForHTMLAttribute(titleModalFaireDemande) %>'
 											   data-statistic='{"name": "declenche-evenement","category": "Téléchargement","action": "<%= fileUrl %>","label": "Faire une demande"}'>
 												<%= itDoc.getTitle() %>

--- a/plugins/SoclePlugin/types/FicheEmploiStage/doFicheEmploiStageFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheEmploiStage/doFicheEmploiStageFullDisplay.jsp
@@ -467,7 +467,7 @@ boolean afficherMentions = !obj.getMasquerMentions();
                                     // Récupérer l'extension du fichier
                                     String fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
                                     // Récupérer la taille du fichier
-                                    String fileSize = Util.formatFileSize(itDoc.getSize(), userLocale);
+                                    String fileSize = Util.formatFileSize(itDoc.getSize());
                                     %>
                                     <li class="mts">
                                         <p class="ds44-docListElem"><i class="icon icon-file ds44-docListIco" aria-hidden="true"></i><a href="<%= itDoc.getDownloadUrl() %>" target="_blank" title='<%= HttpUtil.encodeForHTMLAttribute(itDoc.getTitle()) %> <%= glp("jcmsplugin.socle.accessibily.newTabLabel") %>'><%= itDoc.getTitle() %></a><span class="ds44-cardFile"><%= fileType %> - <%= fileSize %></span></p>

--- a/plugins/SoclePlugin/types/FichePublication/doFichePublicationFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FichePublication/doFichePublicationFullDisplay.jsp
@@ -66,7 +66,7 @@
                                 <%
                                 FileDocument fichierPublication = obj.getDocumentPdf();
                                 String fileTypeFichierPublication = FileDocument.getExtension(fichierPublication.getFilename()).toUpperCase();
-                                String fileSizeFichierPublication = Util.formatFileSize(fichierPublication.getSize(), userLocale,false);
+                                String fileSizeFichierPublication = Util.formatFileSize(fichierPublication.getSize());
                                 %>
                                 <li class="ds44-large-extra-mb ds44-mr-std">
                                     <a href="<%= fichierPublication.getDownloadUrl() %>" class="ds44-btnStd ds44-bntALeft" target="_blank"

--- a/plugins/SoclePlugin/types/FileDocument/doFileDocumentEmbedDisplay.jsp
+++ b/plugins/SoclePlugin/types/FileDocument/doFileDocumentEmbedDisplay.jsp
@@ -4,7 +4,7 @@
 FileDocument obj = (FileDocument)request.getAttribute(PortalManager.PORTAL_PUBLICATION);
 String title = HttpUtil.encodeForHTMLAttribute(obj.getTitle());
 String fileType = FileDocument.getExtension(obj.getFilename()).toUpperCase();
-String fileSize = Util.formatFileSize(obj.getSize(), userLocale,false);
+String fileSize = Util.formatFileSize(obj.getSize());
 %>
 
 	<div class="ds44-docListElem"><i class="icon icon-file ds44-docListIco" aria-hidden="true"></i>

--- a/plugins/SoclePlugin/types/FileDocument/doFileDocumentFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FileDocument/doFileDocumentFullDisplay.jsp
@@ -49,7 +49,7 @@
       <% 
       String ariaLabel = encodeForHTMLAttribute(doc.getTitle(userLang)) + " - " + encodeForHTMLAttribute(doc.getTypeInfo(userLang));
       if (!doc.isRemote()) {
-        ariaLabel += " - " + encodeForHTMLAttribute(Util.formatFileSize(doc.getSize(), userLocale, false));
+        ariaLabel += " - " + encodeForHTMLAttribute(Util.formatFileSize(doc.getSize()));
       }
       %>
       <a class="btn btn-success" href="<%= doc.getDownloadUrl() %>" download="<%= encodeForHTMLAttribute(doc.getDownloadName(userLang)) %>" aria-label='<%= ariaLabel %>'><jalios:icon src="download-btn" /> <%= glp("ui.com.btn.download") %></a>

--- a/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusDocuments.jsp
+++ b/plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusDocuments.jsp
@@ -28,7 +28,7 @@ if (Util.notEmpty(obj.getStyleDeFond()) && !obj.getStyleDeFond().equals("none"))
 	               FileDocument itDoc = (FileDocument)itData;
 	                String title = HttpUtil.encodeForHTMLAttribute(itDoc.getTitle());
 	                String fileType = FileDocument.getExtension(itDoc.getFilename()).toUpperCase();
-	                String fileSize = Util.formatFileSize(itDoc.getSize(), userLocale,false);
+	                String fileSize = Util.formatFileSize(itDoc.getSize());
 	              %>
 	                <li class="mts">
 	                  <jalios:include pub="<%= itDoc %>" usage="embed"/>

--- a/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateMenuCollapseFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateMenuCollapseFullDisplay.jsp
@@ -39,7 +39,7 @@
 						<jalios:if predicate="<%= itContenuPrincipal instanceof FileDocument %>"> 
 							<% 
 								String fileType = " - " + FileDocument.getExtension(((FileDocument)itContenuPrincipal).getFilename()).toUpperCase();
-								String fileSize = " - " + Util.formatFileSize(((FileDocument)itContenuPrincipal).getSize(), userLocale, false);
+								String fileSize = " - " + Util.formatFileSize(((FileDocument)itContenuPrincipal).getSize());
 								String linkTitle = glp("jcmsplugin.socle.fichepublication.telecharger") + " " + itCatLevel2.getName() + fileType + fileSize + " " + glp("jcmsplugin.socle.accessibily.newTabLabel");
 							%>
 							<jalios:link data="<%=itContenuPrincipal%>" css="ds44-collapser_content--buttonLike" title="<%= linkTitle %>" htmlAttributes="target='_blank'"><%=itCatLevel2.getName()%></jalios:link>


### PR DESCRIPTION
Supprime l'abbréviation lors de l'affichage du poids du fichier.
renommage d'un label de title de bouton (fiche aide).