### PR TITLE
EVOL RS-1662 passage multilangue type FAQAccueil

### DIFF
--- a/WEB-INF/data/types/FaqAccueil/FaqAccueil.xml
+++ b/WEB-INF/data/types/FaqAccueil/FaqAccueil.xml
@@ -5,7 +5,7 @@
     <label xml:lang="fr">Titre</label>
   </title>
   <fields>
-    <field name="soustitre" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="true">
+    <field name="soustitre" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="true" html="false" checkHtml="true" descriptionType="tooltip">
       <label xml:lang="fr">Sous-titre</label>
     </field>
     <field type="super" />


### PR DESCRIPTION
https://refonte44.atlassian.net/browse/RS-1662

les gabarits d'FAQAccueil avaient déjà des `userlang` partout, rien à retoucher de ce côté là