### PR TITLE
1638 - Fix lien mailto partage par mail

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/LiensUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/LiensUtils.java
@@ -95,7 +95,7 @@ public final class LiensUtils {
 	 * @return le lien de partage
 	 */
 	public static String createEmailLink(String url, String titrePub) {
-	  return HttpUtil.encodeForURL(JcmsUtil.glp(channel.getCurrentUserLang(), "jcmsplugin.socle.socialnetwork.share.mail.link", channel.getName(), titrePub, HttpUtil.encodeForURL(url)));
+	  return JcmsUtil.glp(channel.getCurrentUserLang(), "jcmsplugin.socle.socialnetwork.share.mail.link", channel.getName(), titrePub, HttpUtil.encodeForURL(url));
 	}	  	  
 
 }

--- a/WEB-INF/classes/fr/cg44/plugin/socle/LiensUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/LiensUtils.java
@@ -95,7 +95,7 @@ public final class LiensUtils {
 	 * @return le lien de partage
 	 */
 	public static String createEmailLink(String url, String titrePub) {
-	  return JcmsUtil.glp(channel.getCurrentUserLang(), "jcmsplugin.socle.socialnetwork.share.mail.link", channel.getName(), titrePub, HttpUtil.encodeForURL(url));
+	  return JcmsUtil.glp(channel.getCurrentUserLang(), "jcmsplugin.socle.socialnetwork.share.mail.link", channel.getName(), HttpUtil.encodeForURL(titrePub), HttpUtil.encodeForURL(url));
 	}	  	  
 
 }

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -179,7 +179,7 @@ jcmsplugin.socle.socialnetwork.share.twitter: Partager cette page sur Twitter - 
 jcmsplugin.socle.socialnetwork.share.instagram: Partager cette page sur Instagram - nouvelle fenêtre
 jcmsplugin.socle.socialnetwork.share.linkedin: Partager cette page sur Linkedin - nouvelle fenêtre
 jcmsplugin.socle.socialnetwork.share.mail: Partager cette page par email - nouvelle fenêtre
-jcmsplugin.socle.socialnetwork.share.mail.link: mailto:?subject=Une page pour vous sur {0} : {1}&body=Bonjour, cette page devrait vous intéresser : %0D%0A{2} 
+jcmsplugin.socle.socialnetwork.share.mail.link: mailto:?subject=Une%20page%20pour%20vous%20sur%20{0}%20:%20{1}&body=Bonjour,%20cette%20page%20devrait%20vous%20intéresser%20:%20%0D%0A{2} 
 
 # ------------------------------------------------------------
 #  Libellés communs


### PR DESCRIPTION
Encoder le mailto:? et autres paramètres causait soucis. Nul besoin d'encoder l'URL dans le paramètre normalement (censé être déjà encodé pour) mais laissé au cas où. Ca passe avec et sans de mon côté sur ThunderBird.