### PR TITLE
Evol : header multilingue

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -10,3 +10,10 @@ jcmsplugin.socle.dossier.fermer-menu-sommaire : Close the summary menu
 # ------------------------------------------------------------
 jcmsplugin.socle.video.telecharger-transcript.label: Download the video transcription file
 jcmsplugin.socle.video.telecharger-transcript.title: Download the video transcription file : {0} - {1} - {2} - new tab
+
+
+# ------------------------------------------------------------
+#  # Multilingue
+# ------------------------------------------------------------
+jcmsplugin.socle.multilingue.english-version.title: English : visit the english version of the site {0}
+jcmsplugin.socle.multilingue.french-version.title: French : visit the french version of the site {0}

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -807,3 +807,7 @@ jcmsplugin.socle.chiffrescles.lien: Toutes les données
 
 # FALC
 jcmsplugin.socle.falc.titre: Facile À Lire et À Comprendre (FALC)
+
+# Multilingue
+jcmsplugin.socle.multilingue.english-version.title: English : consultez la version anglaise du site {0}
+jcmsplugin.socle.multilingue.french-version.title: French : consultez la version française du site {0}

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -692,3 +692,12 @@ upload.permission.size.audio: 104857600
 upload.permission.size.video: 104857600
 # 100Mo max pour tout autre type (non pris en compte par les confs précédentes)
 upload.permission.size.default: 104857600
+
+# ------------------------------------------------------------
+#  Multilingues
+# ------------------------------------------------------------
+jcmsplugin.socle.multilingue: false
+jcmsplugin.socle.multilingue.english-version.label: English
+jcmsplugin.socle.multilingue.french-version.label: French
+jcmsplugin.socle.multilingue.english-version.title: English version
+jcmsplugin.socle.multilingue.french-version.title: French version

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -699,5 +699,3 @@ upload.permission.size.default: 104857600
 jcmsplugin.socle.multilingue: false
 jcmsplugin.socle.multilingue.english-version.label: English
 jcmsplugin.socle.multilingue.french-version.label: French
-jcmsplugin.socle.multilingue.english-version.title: English version
-jcmsplugin.socle.multilingue.french-version.title: French version

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -18,8 +18,30 @@ Category subMenuRootCat = channel.getCategory(subMenuRootCatId);
 Set<Category> subMenuCatList = Util.notEmpty(subMenuRootCat) ? SocleUtils.getOrderedAuthorizedChildrenSet(subMenuRootCat) : new HashSet<Category>();
 
 boolean displaySearchMenu = channel.getBooleanProperty("jcmsplugin.socle.site.header.show.rechercher", true);
-%>
 
+boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
+String changeLang = "";
+String langIcon = "";
+String langLabel = "";
+String langTitle = "";
+String changeLangUrl = "";
+
+if(multilingue){
+	if(userLang.equals("fr")){
+	  changeLang = "en";
+	  langIcon = "icon-english";
+	  langLabel = channel.getProperty("jcmsplugin.socle.multilingue.english-version.label");
+	  langTitle = channel.getProperty("jcmsplugin.socle.multilingue.english-version.title");
+	}
+	else{
+	  changeLang = "fr";
+	  langIcon = "icon-french";
+	  langLabel = channel.getProperty("jcmsplugin.socle.multilingue.french-version.label");
+	  langTitle = channel.getProperty("jcmsplugin.socle.multilingue.french-version.title");
+	}
+	changeLangUrl = LangTag.getChangeUrl(request, changeLang);
+}
+%>
 
 <header role="banner" id="topPage">
     <div class="ds44-blocBandeau ds44-header">
@@ -44,7 +66,12 @@ boolean displaySearchMenu = channel.getBooleanProperty("jcmsplugin.socle.site.he
                         </picture>
                     </a>
                 </div>
-                <div class="ds44-colRight">            
+                <div class="ds44-colRight">
+                    <jalios:if predicate='<%= multilingue %>'>
+	                    <a href="<%= changeLangUrl %>" class="ds44-btnIcoText--maxi ds44--xl-padding" title="<%= langTitle %>">
+	                        <span class="ds44-btnInnerText"><%= langLabel %></span><i class="icon icon--large <%= langIcon %>" aria-hidden="true"></i>
+	                    </a>
+                    </jalios:if>
                     <jalios:if predicate="<%= displaySearchMenu %>">
                         <button class="ds44-btnIcoText--maxi ds44--xl-padding" type="button" id="open-search">
                            <span class="ds44-btnInnerText"><%=glp("jcmsplugin.socle.rechercher")%></span><i class="icon icon-magnifier icon--large" aria-hidden="true"></i>

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -31,13 +31,13 @@ if(multilingue){
 	  changeLang = "en";
 	  langIcon = "icon-english";
 	  langLabel = channel.getProperty("jcmsplugin.socle.multilingue.english-version.label");
-	  langTitle = channel.getProperty("jcmsplugin.socle.multilingue.english-version.title");
+	  langTitle = glp("jcmsplugin.socle.multilingue.english-version.title", glp("jcmsplugin.socle.nomDuSite"));
 	}
 	else{
 	  changeLang = "fr";
 	  langIcon = "icon-french";
 	  langLabel = channel.getProperty("jcmsplugin.socle.multilingue.french-version.label");
-	  langTitle = channel.getProperty("jcmsplugin.socle.multilingue.french-version.title");
+	  langTitle = glp("jcmsplugin.socle.multilingue.french-version.title", glp("jcmsplugin.socle.nomDuSite"));
 	}
 	changeLangUrl = LangTag.getChangeUrl(request, changeLang);
 }


### PR DESCRIPTION
Ajout d'une prop pour indiquer si le site est multilingue ou non
Ajout de prop pour les libellés
Gestion du changement de langue dans le fichier commun du header.