### PR TITLE
Fix formulaire contact (RS-1651)

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/MailUtils.java
@@ -26,6 +26,8 @@ public final class MailUtils {
 
   private static final Logger LOGGER = Logger.getLogger(MailUtils.class);
   private static final String NEWLINE = "<br/><br>";
+  private static final String prefixeObjetMail = Util.notEmpty(channel.getProperty("fr.jcmsplugin.socle.nomDuSite")) ? channel.getProperty("fr.jcmsplugin.socle.nomDuSite") : channel.getName();
+  
 
   public MailUtils() {
     throw new IllegalStateException("Utility class");
@@ -35,10 +37,11 @@ public final class MailUtils {
    * Envoi d'un email de contact.
    */
   public static void envoiMailContact(ContactForm form, String emailTo) {
+    boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
     String jsp = "/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp";
 
     // Objet
-    String objet = JcmsUtil.glp(channel.getDefaultAdmin().getLanguage(), "jcmsplugin.socle.email.contact.objet", form.getSujet(channel.getDefaultAdmin()).first().getName());
+    String objet = prefixeObjetMail + " - " + form.getSujet(channel.getDefaultAdmin()).first().getName();
 
     // Contenu
     HashMap<Object, Object> parametersMap = new HashMap<Object, Object>();
@@ -46,10 +49,15 @@ public final class MailUtils {
     parametersMap.put("prenom", form.getPrenom());
     parametersMap.put("email", form.getMail());
     parametersMap.put("telephone", Util.notEmpty(form.getTelephone()) ? form.getTelephone() : "");
+    parametersMap.put("structure", Util.notEmpty(form.getStructure()) ? form.getStructure() : "");
     parametersMap.put("adresse", Util.notEmpty(form.getAdresse()) ? form.getAdresse() : "");
     parametersMap.put("complement-adresse", Util.notEmpty(form.getComplementDadresse()) ? form.getComplementDadresse() : "");
-    parametersMap.put("codepostal", form.getCodePostal());
-    parametersMap.put("commune", SocleUtils.getCitynameFromZipcode(form.getCodePostal()));
+    parametersMap.put("codepostal", Util.notEmpty(form.getCodePostal()) ? form.getCodePostal() : "");
+    if(!multilingue && Util.notEmpty(form.getCodePostal())) {
+      parametersMap.put("commune", SocleUtils.getCitynameFromZipcode(form.getCodePostal()));
+    }
+    parametersMap.put("ville", Util.notEmpty(form.getVille()) ? form.getVille() : "");
+    parametersMap.put("pays", Util.notEmpty(form.getPays()) ? form.getPays() : "");
     parametersMap.put("sujet", form.getSujet(channel.getDefaultAdmin()).first());
     parametersMap.put("message", form.getMessage());
 
@@ -69,7 +77,7 @@ public final class MailUtils {
    */
   public static void envoiMailCandidatureSpontanee(CandidatureSpontaneeForm form, ArrayList<File> fichiers) {
     // Objet
-    String objet = JcmsUtil.glp(channel.getDefaultAdmin().getLanguage(), "jcmsplugin.socle.email.candidature-spontanee.objet");
+    String objet = prefixeObjetMail +" - " + JcmsUtil.glpd("jcmsplugin.socle.email.candidature-spontanee.objet");
 
     // Contenu
     StringBuilder contenu = new StringBuilder("Expediteur : ");
@@ -133,7 +141,7 @@ public final class MailUtils {
       }
 
     // Objet
-    String objet = JcmsUtil.glp(channel.getDefaultAdmin().getLanguage(), "jcmsplugin.socle.email.candidature.objet", form.getReference());
+    String objet = prefixeObjetMail +" - " + JcmsUtil.glp("jcmsplugin.socle.email.candidature.objet", form.getReference());
 
     StringBuilder contenu = new StringBuilder("Expediteur : ");
     contenu.append("  " + form.getNom() + " "+ form.getPrenom() + " a repondu à l'annonce " + form.getReference() + " – " + jobTitle + NEWLINE);
@@ -174,7 +182,7 @@ public final class MailUtils {
     String jsp = "/plugins/SoclePlugin/jsp/mail/formulaireFaqTemplate.jsp";
     
     // Objet
-    String objet = channel.getName() + " - " + JcmsUtil.glpd("jcmsplugin.socle.email.faq.objet");
+    String objet = prefixeObjetMail +" - " + JcmsUtil.glpd("jcmsplugin.socle.email.faq.objet");
 
     // Publication concernée par la FAQ
     Publication pub = channel.getPublication(request.getParameter("id[value]"));
@@ -229,9 +237,8 @@ public final class MailUtils {
     String jsp = "/plugins/SoclePlugin/jsp/mail/formulairePageUtileTemplate.jsp";
     
     // Objet
-    StringBuffer objet = new StringBuffer();
-    objet.append(channel.getName()).append(" / ");
-    objet.append(pageUtile ? JcmsUtil.glpd("jcmsplugin.socle.email.pageutile.objet.utile") : JcmsUtil.glpd("jcmsplugin.socle.email.pageutile.objet.inutile"));
+    String objet = prefixeObjetMail + " / ";
+    objet += pageUtile ? JcmsUtil.glpd("jcmsplugin.socle.email.pageutile.objet.utile") : JcmsUtil.glpd("jcmsplugin.socle.email.pageutile.objet.inutile");
 
     // Contenu
     HashMap<Object, Object> parametersMap = new HashMap<Object, Object>();

--- a/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/ContactFormDataController.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/ContactFormDataController.java
@@ -33,25 +33,26 @@ public class ContactFormDataController extends BasicDataController implements Pl
   ContactForm form = (ContactForm) data;
   String userLang = channel.getCurrentUserLang();
   HttpServletRequest req = channel.getCurrentServletRequest();
+  boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
   
  	boolean isOK = true;
 
   // Nom
   if (Util.isEmpty(form.getNom())) {
     isOK = false;
-    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "nom", userLang)));
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.nom")));
   }
 
   // Prénom
   if (Util.isEmpty(form.getPrenom())) {
    isOK = false;
-   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "prenom", userLang)));
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.prenom")));
   }
 
   // Mail
   if (Util.isEmpty(form.getMail())) {
    isOK = false;
-   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "email", userLang)));
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.mail")));
   }
   
   if (Util.notEmpty(form.getMail())) {
@@ -59,14 +60,14 @@ public class ContactFormDataController extends BasicDataController implements Pl
    boolean correspond = Pattern.matches(regexp, form.getMail());
    if (!correspond) {
     isOK = false;
-    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "email", userLang)));
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.mail")));
    }
   } 
 
   // Code postal
- 	if(Util.isEmpty(form.getCodePostal())) {
+ 	if(!multilingue && Util.isEmpty(form.getCodePostal())) {
    isOK = false;
-   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "codePostal", userLang)));
+   JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.code-postal")));
  	}
  	
   if (Util.notEmpty(form.getCodePostal())) {
@@ -74,7 +75,7 @@ public class ContactFormDataController extends BasicDataController implements Pl
    boolean correspond = Pattern.matches(regexp, form.getCodePostal());
    if (!correspond) {
     isOK = false;
-    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "codePostal", userLang)));
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.code-postal")));
    }
  }  
   
@@ -84,20 +85,26 @@ public class ContactFormDataController extends BasicDataController implements Pl
    boolean correspond = Pattern.matches(regexp, form.getTelephone());
    if (!correspond) {
     isOK = false;
-    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "telephone", userLang)));
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.telephone")));
    }
  }
+  
+  // Pays
+  if (multilingue && Util.isEmpty(form.getPays())) {
+    isOK = false;
+    JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.pays")));
+ }  
 
   // Sujet
   if (Util.isEmpty(form.getSujet(channel.getDefaultAdmin()))) {
   	isOK = false;
-  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "sujet", userLang)));
+  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.sujet")));
   }
 
   // Message
   if (Util.isEmpty(form.getMessage())) {
   	isOK = false;
-  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, channel.getTypeFieldLabel(ContactForm.class, "message", userLang)));
+  	JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.votre-message")));
   }
 
   // Formulaire non valide. On value le titre de la messageBox.

--- a/WEB-INF/data/types/ContactForm/ContactForm.xml
+++ b/WEB-INF/data/types/ContactForm/ContactForm.xml
@@ -15,6 +15,9 @@
     <field name="mail" editor="email" required="false" compactDisplay="false" type="String" searchable="false" size="50" maxlength="500" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
       <label xml:lang="fr">Courriel</label>
     </field>
+    <field name="structure" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Structure</label>
+    </field>    
     <field name="adresse" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
       <label xml:lang="fr">Adresse</label>
     </field>
@@ -24,9 +27,15 @@
     <field name="codePostal" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="5" ml="false" html="false" checkHtml="false" descriptionType="text" maxlength="5">
       <label xml:lang="fr">Code postal</label>
     </field>
+    <field name="ville" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Ville</label>
+    </field>    
+    <field name="pays" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Pays</label>
+    </field>
     <field name="telephone" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
       <label xml:lang="fr">Téléphone</label>
-    </field>
+    </field>        
     <field name="sujet" editor="category" required="false" compactDisplay="false" type="java.util.TreeSet" chooser="listbox" exclusive="true" root="$jcmsplugin.socle.form.contactform.sujet.root" ml="false" descriptionType="text" searchable="false" html="false" checkHtml="true" displayRoot="false">
       <label xml:lang="fr">Sujet</label>
     </field>

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -126,16 +126,16 @@ $jcmsplugin.socle.login.pub : Contenu à viser pour la réinitialisation du mot 
 jcmsplugin.socle.form.login.oublie-passe: Forgot your password ?
 jcmsplugin.socle.form.contact-mail.title: Contact form
 jcmsplugin.socle.form.contact-mail.origine: Loire Atlantique Departement
+jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
 
 # ------------------------------------------------------------
 #  Mail
 # ------------------------------------------------------------
 jcmsplugin.socle.email.message.succes : Thank you, your message was sent successfully
 jcmsplugin.socle.email.message.echec : An error occurred while sending the email.
-jcmsplugin.socle.email.contact.objet: Loire-Atlantique.fr - {0}
-jcmsplugin.socle.email.candidature-spontanee.objet: Loire-Atlantique.fr - Candidature spontanée
-jcmsplugin.socle.email.candidature.objet: Loire-Atlantique.fr - Réponse à l'offre d'emploi - {0}
-jcmsplugin.socle.email.faq.objet: Loire-Atlantique.fr - FAQ
+jcmsplugin.socle.email.candidature-spontanee.objet: Candidature spontanée
+jcmsplugin.socle.email.candidature.objet: Réponse à l'offre d'emploi - {0}
+jcmsplugin.socle.email.faq.objet: FAQ
 jcmsplugin.socle.email.pageutile.objet.utile: HELPFUL
 jcmsplugin.socle.email.pageutile.objet.inutile: NOT HELPFUL
 
@@ -297,6 +297,8 @@ jcmsplugin.socle.pays: Country
 jcmsplugin.socle.question: Question
 jcmsplugin.socle.lien: Link
 jcmsplugin.socle.page-concernee: Page concerned
+jcmsplugin.socle.structure: Structure
+jcmsplugin.socle.ville: City
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -126,15 +126,15 @@ $jcmsplugin.socle.login.pub : Contenu à viser pour la réinitialisation du mot 
 jcmsplugin.socle.form.login.oublie-passe: Mot de passe oublié ?
 jcmsplugin.socle.form.contact-mail.title: Formulaire de contact
 jcmsplugin.socle.form.contact-mail.origine: Département de Loire Atlantique
+jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
 
 # ------------------------------------------------------------
 #  Mail
 # ------------------------------------------------------------
 jcmsplugin.socle.email.message.succes : Merci, votre message a été envoyé.
 jcmsplugin.socle.email.message.echec : Une erreur s'est produite lors de l'envoi de l'email.
-jcmsplugin.socle.email.contact.objet: Loire-Atlantique.fr - {0}
-jcmsplugin.socle.email.candidature-spontanee.objet: Loire-Atlantique.fr - Candidature spontanée
-jcmsplugin.socle.email.candidature.objet: Loire-Atlantique.fr - Réponse à l'offre d'emploi - {0}
+jcmsplugin.socle.email.candidature-spontanee.objet: Candidature spontanée
+jcmsplugin.socle.email.candidature.objet: Réponse à l'offre d'emploi - {0}
 jcmsplugin.socle.email.faq.objet: FAQ
 jcmsplugin.socle.email.pageutile.objet.utile: UTILE
 jcmsplugin.socle.email.pageutile.objet.inutile: PAS UTILE
@@ -297,6 +297,8 @@ jcmsplugin.socle.pays: Pays
 jcmsplugin.socle.question: Question
 jcmsplugin.socle.lien: Lien
 jcmsplugin.socle.page-concernee: Page concernée
+jcmsplugin.socle.structure: Structure
+jcmsplugin.socle.ville: Ville
 
 # ------------------------------------------------------------
 #  Header

--- a/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/mail/formulaireContactTemplate.jsp
@@ -307,16 +307,31 @@ MOBILE TARGETING
                         <td>
                         <p><%= glp("jcmsplugin.socle.nom") %> : <%=request.getAttribute("nom") %></p>
                         <p><%= glp("jcmsplugin.socle.prenom") %> : <%=request.getAttribute("prenom") %></p>
-                        <p><%= glp("jcmsplugin.socle.pageutile.email") %> : <%=request.getAttribute("email") %></p>
-                        <p><%= glp("jcmsplugin.socle.telephone") %> : <%=request.getAttribute("telephone") %></p>
+                        <p><%= glp("jcmsplugin.socle.mail") %> : <%=request.getAttribute("email") %></p>
+                        <% if(Util.notEmpty(request.getAttribute("telephone"))) { %>
+                          <p><%= glp("jcmsplugin.socle.telephone") %> : <%=request.getAttribute("telephone") %></p>
+                        <% } %>
+                        <% if(Util.notEmpty(request.getAttribute("structure"))) { %>
+                          <p><%= glp("jcmsplugin.socle.structure") %> : <%=request.getAttribute("structure") %></p>
+                        <% } %>
                         <% if(Util.notEmpty(request.getAttribute("adresse"))) { %>
                           <p><%= glp("jcmsplugin.socle.adresse") %> : <%=request.getAttribute("adresse") %></p>
                         <% } %>
                         <% if(Util.notEmpty(request.getAttribute("complement-adresse"))) { %>
                           <p><%= glp("jcmsplugin.socle.complement-adresse") %> : <%=request.getAttribute("complement-adresse") %></p>
                         <% } %>
-                        <p><%= glp("jcmsplugin.socle.code-postal") %> : <%=request.getAttribute("codepostal") %></p>
-                        <p><%= glp("jcmsplugin.socle.facette.commune.default-label") %> : <%=request.getAttribute("commune") %></p>
+                        <% if(Util.notEmpty(request.getAttribute("codepostal"))) { %>
+                          <p><%= glp("jcmsplugin.socle.code-postal") %> : <%=request.getAttribute("codepostal") %></p>
+                        <% } %>
+                        <% if(Util.notEmpty(request.getAttribute("commune"))) { %>
+                          <p><%= glp("jcmsplugin.socle.facette.commune.default-label") %> : <%=request.getAttribute("commune") %></p>
+                        <% } %>
+                        <% if(Util.notEmpty(request.getAttribute("ville"))) { %>
+                          <p><%= glp("jcmsplugin.socle.ville") %> : <%=request.getAttribute("ville") %></p>
+                        <% } %>                        
+                        <% if(Util.notEmpty(request.getAttribute("pays"))) { %>
+                          <p><%= glp("jcmsplugin.socle.pays") %> : <%=request.getAttribute("pays") %></p>
+                        <% } %>
                         <p><%= glp("jcmsplugin.socle.sujet") %> : <%=request.getAttribute("sujet") %></p>
                         <p><%= glp("jcmsplugin.socle.message") %> : <%=request.getAttribute("message") %></p>
                         </td>

--- a/plugins/SoclePlugin/types/ContactForm/doEditContactForm.jsp
+++ b/plugins/SoclePlugin/types/ContactForm/doEditContactForm.jsp
@@ -12,6 +12,8 @@
   EditContactFormHandler formHandler = (EditContactFormHandler)request.getAttribute("formHandler");
   ServletUtil.backupAttribute(pageContext, "classBeingProcessed");
   request.setAttribute("classBeingProcessed", generated.ContactForm.class);
+  
+  boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
 %>
 <%-- Name ------------------------------------------------------------ --%>
 <% String nomLabel = glp("jcmsplugin.socle.nom"); %>
@@ -71,6 +73,7 @@
 </div>
 
 <%-- Phone ------------------------------------------------------------ --%>
+<jalios:if predicate='<%= userLang.equals("fr") %>'>
 <% String telephoneLabel = glp("jcmsplugin.socle.telephone"); %>
 <div class="ds44-mb3">
     <div class="ds44-form__container">
@@ -90,70 +93,170 @@
         </div>
     </div>
 </div>
+</jalios:if>
 
 <%-- Adresse ------------------------------------------------------------ --%>
-<% String adresseLabel = glp("jcmsplugin.socle.adresse"); %>
-<div class="ds44-mb3">
-    <div class="ds44-form__container">
-        <div class="ds44-posRel">
-            <label for="form-element-adresse" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= adresseLabel %></span></span>
-            </label>
-            <input type="text" id="form-element-adresse" name="adresse" class="ds44-inpStd" aria-describedby="explanation-form-element-adresse">
-            <button class="ds44-reset" type="button">
-                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", adresseLabel) %></span>
-            </button>
-        </div>
-        <div class="ds44-field-information" aria-live="polite">
-            <ul class="ds44-field-information-list ds44-list">
-                <li id="explanation-form-element-adresse" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.adresse") %></li>
-            </ul>
-        </div>
-    </div>
-</div>
+<jalios:if predicate='<%= ! multilingue %>'>
+	<% String adresseLabel = glp("jcmsplugin.socle.adresse"); %>
+	<div class="ds44-mb3">
+	    <div class="ds44-form__container">
+	        <div class="ds44-posRel">
+	            <label for="form-element-adresse" class="ds44-formLabel">
+	                <span class="ds44-labelTypePlaceholder"><span><%= adresseLabel %></span></span>
+	            </label>
+	            <input type="text" id="form-element-adresse" name="adresse" class="ds44-inpStd" aria-describedby="explanation-form-element-adresse">
+	            <button class="ds44-reset" type="button">
+	                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", adresseLabel) %></span>
+	            </button>
+	        </div>
+	        <div class="ds44-field-information" aria-live="polite">
+	            <ul class="ds44-field-information-list ds44-list">
+	                <li id="explanation-form-element-adresse" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.adresse") %></li>
+	            </ul>
+	        </div>
+	    </div>
+	</div>
+</jalios:if>
+
 
 <%-- complementDadresse ------------------------------------------------------------ --%>
-<% String complementDAdresseLabel = glp("jcmsplugin.socle.complement-adresse"); %>
-<div class="ds44-mb3">
-    <div class="ds44-form__container">
-        <div class="ds44-posRel">
-            <label for="form-element-complement-adresse" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= complementDAdresseLabel %></span></span>
-            </label>
-            <input type="text" id="form-element-complement-adresse" name="complementDadresse" class="ds44-inpStd" aria-describedby="explanation-form-element-complement-adresse">
-            <button class="ds44-reset" type="button">
-                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", complementDAdresseLabel) %></span>
-            </button>
-        </div>
-        <div class="ds44-field-information" aria-live="polite">
-            <ul class="ds44-field-information-list ds44-list">
-                <li id="explanation-form-element-complement-adresse" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.complement-adresse") %></li>
-            </ul>
+<jalios:if predicate='<%= ! multilingue %>'>
+	<% String complementDAdresseLabel = glp("jcmsplugin.socle.complement-adresse"); %>
+	<div class="ds44-mb3">
+	    <div class="ds44-form__container">
+	        <div class="ds44-posRel">
+	            <label for="form-element-complement-adresse" class="ds44-formLabel">
+	                <span class="ds44-labelTypePlaceholder"><span><%= complementDAdresseLabel %></span></span>
+	            </label>
+	            <input type="text" id="form-element-complement-adresse" name="complementDadresse" class="ds44-inpStd" aria-describedby="explanation-form-element-complement-adresse">
+	            <button class="ds44-reset" type="button">
+	                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", complementDAdresseLabel) %></span>
+	            </button>
+	        </div>
+	        <div class="ds44-field-information" aria-live="polite">
+	            <ul class="ds44-field-information-list ds44-list">
+	                <li id="explanation-form-element-complement-adresse" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.complement-adresse") %></li>
+	            </ul>
+	        </div>
+	    </div>
+	</div>
+</jalios:if>
+
+<%-- structure ------------------------------------------------------------ --%>
+<jalios:if predicate='<%= multilingue && userLang.equals("fr") %>'>
+    <% String structureLabel = glp("jcmsplugin.socle.structure"); %>
+    <div class="ds44-mb3">
+        <div class="ds44-form__container">
+            <div class="ds44-posRel">
+                <label for="form-element-structure" class="ds44-formLabel">
+                    <span class="ds44-labelTypePlaceholder"><span><%= structureLabel %></span></span>
+                </label>
+                <input type="text" id="form-element-structure" name="structure" class="ds44-inpStd" aria-describedby="explanation-form-element-structure">
+                <button class="ds44-reset" type="button">
+                    <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", structureLabel) %></span>
+                </button>
+            </div>
+            <div class="ds44-field-information" aria-live="polite">
+                <ul class="ds44-field-information-list ds44-list">
+                    <li id="explanation-form-element-structure" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.structure") %></li>
+                </ul>
+            </div>
         </div>
     </div>
-</div>
- 
+</jalios:if>
+
 <%-- CodePostal ------------------------------------------------------------ --%>
-<% String codepostalLabel = glp("jcmsplugin.socle.code-postal"); %>
-<div class="ds44-mb3">
-    <div class="ds44-form__container">
-        <div class="ds44-posRel">
-            <label for="form-element-codepostal" class="ds44-formLabel">
-                <span class="ds44-labelTypePlaceholder"><span><%= codepostalLabel %><sup aria-hidden="true">*</sup></span></span>
-            </label>
-            <input type="text" id="form-element-codepostal" name="codePostal" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", codepostalLabel) %>"
-                required autocomplete="postal-code" aria-describedby="explanation-form-element-codepostal">
-            <button class="ds44-reset" type="button">
-                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", codepostalLabel) %></span>
-            </button>
-        </div>
-        <div class="ds44-field-information" aria-live="polite">
-            <ul class="ds44-field-information-list ds44-list">
-                <li id="explanation-form-element-codepostal" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.codepostal") %></li>
-            </ul>
+<jalios:if predicate='<%= ! multilingue %>'>
+	<% String codepostalLabel = glp("jcmsplugin.socle.code-postal"); %>
+	<div class="ds44-mb3">
+	    <div class="ds44-form__container">
+	        <div class="ds44-posRel">
+	            <label for="form-element-codepostal" class="ds44-formLabel">
+	                <span class="ds44-labelTypePlaceholder"><span><%= codepostalLabel %><sup aria-hidden="true">*</sup></span></span>
+	            </label>
+	            <input type="text" id="form-element-codepostal" name="codePostal" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", codepostalLabel) %>"
+	                required autocomplete="postal-code" aria-describedby="explanation-form-element-codepostal">
+	            <button class="ds44-reset" type="button">
+	                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", codepostalLabel) %></span>
+	            </button>
+	        </div>
+	        <div class="ds44-field-information" aria-live="polite">
+	            <ul class="ds44-field-information-list ds44-list">
+	                <li id="explanation-form-element-codepostal" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.codepostal") %></li>
+	            </ul>
+	        </div>
+	    </div>
+	</div>
+</jalios:if>
+
+<%-- CodePostal ML (non obligatoire) -------------------------------------------------------- --%>
+<jalios:if predicate='<%= multilingue && userLang.equals("fr") %>'>
+    <% String codepostalLabel = glp("jcmsplugin.socle.code-postal"); %>
+    <div class="ds44-mb3">
+        <div class="ds44-form__container">
+            <div class="ds44-posRel">
+                <label for="form-element-codepostal" class="ds44-formLabel">
+                    <span class="ds44-labelTypePlaceholder"><span><%= codepostalLabel %></span></span>
+                </label>
+                <input type="text" id="form-element-codepostal" name="codePostal" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", codepostalLabel) %>"
+                    autocomplete="postal-code" aria-describedby="explanation-form-element-codepostal">
+                <button class="ds44-reset" type="button">
+                    <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", codepostalLabel) %></span>
+                </button>
+            </div>
+            <div class="ds44-field-information" aria-live="polite">
+                <ul class="ds44-field-information-list ds44-list">
+                    <li id="explanation-form-element-codepostal" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.codepostal") %></li>
+                </ul>
+            </div>
         </div>
     </div>
-</div>
+</jalios:if>
+
+<%-- Ville ------------------------------------------------------------ --%>
+<jalios:if predicate='<%= multilingue && userLang.equals("fr") %>'>
+    <% String villeLabel = glp("jcmsplugin.socle.ville"); %>
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-ville" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder">
+                    <span class="ds44-labelTypePlaceholder"><%= villeLabel %></span>
+                </span>
+            </label>
+            <input type="text" id="form-element-ville" name="ville" class="ds44-inpStd" />
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i>
+                <span class="visually-hidden">
+                    <%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", villeLabel) %>
+                </span>
+            </button> 
+            
+        </div>
+    </div>
+</jalios:if>
+
+<jalios:if predicate='<%= multilingue %>'>
+    <%-- Pays ------------------------------------------------------------ --%>
+    <% String paysLabel = glp("jcmsplugin.socle.pays"); %>
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-pays" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder">
+                    <span class="ds44-labelTypePlaceholder"><%= paysLabel %><sup aria-hidden="true">*</sup></span>
+                </span>
+            </label>
+            <input type="text" id="form-element-pays" name="pays" class="ds44-inpStd" required
+                   title='<%= glp("jcmsplugin.socle.faq.selectionner-pays") %>' />
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i>
+                <span class="visually-hidden">
+                    <%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", paysLabel) %>
+                </span>
+            </button> 
+            
+        </div>
+    </div>
+</jalios:if>
 
 <%-- Sujet ------------------------------------------------------------ --%>
 <% String sujetLabel = glp("jcmsplugin.socle.sujet"); %>


### PR DESCRIPTION
Champs différents en FR et EN, mais aussi entre la version FR multilingue et FR normale.
Type de formulaire unique mais gestion de ces cas de figure dans le gabarit de form + datacontroller
Refacto des objets de mail + suppression d'une prop inutile.