### PR TITLE
hotfix tag titleBanner

### DIFF
--- a/WEB-INF/tags/titleBanner.tag
+++ b/WEB-INF/tags/titleBanner.tag
@@ -15,7 +15,7 @@
     description="Le titre affiché sur l'image"
 %>
 <%@ attribute name="subtitle"
-    required="true"
+    required="false"
     fragment="false"
     rtexprvalue="true"
     type="String"


### PR DESCRIPTION
Ne pas mettre le nouveau champ "subtitle" obligatoire, car gros impact sur les gabarits existants