### PR TITLE
Fix objet de mail

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -1,3 +1,4 @@
+jcmsplugin.socle.nomDuSite: 
 plugin.socle.newsPortalCategory: Catégorie du portail d'actualités
 jcmsplugin.socle.label.error.warnAdmin: Une erreur est survenue. Veuillez prévenir l'administrateur du site.
 

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -1,3 +1,4 @@
+jcmsplugin.socle.nomDuSite: 
 plugin.socle.newsPortalCategory: Catégorie du portail d'actualités
 jcmsplugin.socle.label.error.warnAdmin: Une erreur est survenue. Veuillez prévenir l'administrateur du site.
 


### PR DESCRIPTION
Rajout de propriétés pour corriger un bug dans les envois de mail.
Ces props sont à surcharger dans custom.prop pour chaque site ayant un besoin de personnalisation de l'objet du mail.