### PR TITLE
Fix temporaire récupération thématiques perso

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -1047,7 +1047,7 @@ public class InfolocaleEntityUtils {
       }
       mapGenre = getAllThematiquesWithLibelles(fluxId, lblClone, idThematiques);
     } else {
-      mapGenre = getAllThematiquesWithLibelles(fluxId, idThematiques, idThematiques);
+      mapGenre = getAllThematiquesWithLibelles(fluxId, lblThematiques, idThematiques);
     }
     
     return mapGenre;

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
@@ -9,6 +9,7 @@ import org.apache.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONArray;
 
 import com.jalios.jcms.Channel;
 import com.jalios.util.Util;
@@ -343,7 +344,11 @@ public class RequestManager {
                   }
                   else if (Util.isEmpty(metadata) || Util.notEmpty(responseContent)) {
                     fluxData = new JSONObject();
-                    fluxData.put("listMetadata", new JSONObject(responseContent));
+                    if (responseContent.startsWith("[")) {
+                      fluxData.put("listMetadata", new JSONObject(responseContent.replaceFirst("\\[", "").replace("}]}]", "}]}")));
+                    } else {
+                      fluxData.put("listMetadata", new JSONObject(responseContent));
+                    }
                   } else {
                     fluxData = new JSONObject(responseContent);
                   }

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -480,6 +480,7 @@ jcmsplugin.socle.infolocale.login:
 jcmsplugin.socle.infolocale.password: 
 jcmsplugin.socle.infolocale.limit: 20
 jcmsplugin.socle.infolocale.flux.default: f24ba875-a641-47aa-b1b5-01c23a1b6812
+jcmsplugin.socle.infolocale.flux.metadata: b47b84d4-35eb-4ae3-ad14-700cc376f471
 jcmsplugin.socle.infolocale.defaultOrder: dateDebut asc
 jcmsplugin.socle.infolocale.flux.url: https://api.infolocale.fr/flux/
 jcmsplugin.socle.infolocale.extract.url: https://api.infolocale.fr/annonces/


### PR DESCRIPTION
Les métadonnées Infolocale ne peuvent être récupérées que sur un flux particulier. L'idée est de forcer cet ID de flux uniquement pour la récupération des thématiques personnalisées.
Inclut un fix pour le libellé des catégories agenda, et prend en compte la possibilité d'une donnée renvoyée en tant qu'array JSON et non pas en tant qu'objet.
Sera revu avec infolocale une fois un développeur revenu de congés de leur côté (mention d'une récupération possible via un autre endpoint)

Ce fix est proposé pour que la facette catégorie agenda soit fonctionnelle en production d'ici là.