### PR TITLE
1736 - Fix API notes récupéraient mauvaises données

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/api/ApiNotesCacheManager.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/api/ApiNotesCacheManager.java
@@ -75,9 +75,9 @@ public enum ApiNotesCacheManager {
   }
 
   public void refreshBeanData() {
-    String placeIdGoogle = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.google.key");
-    String placeIdTripadvisor = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.tripadvisor.key");
-    String placeIdFacebook = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.facebook.key");
+    String placeIdGoogle = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.google.id");
+    String placeIdTripadvisor = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.tripadvisor.id");
+    String placeIdFacebook = Channel.getChannel().getProperty("jcmsplugin.socle.api.places.facebook.id");
     
     // Google
     GooglePlaceBean googleBean = GoogleApiManager.getGooglePlaceBeanFromId(placeIdGoogle);


### PR DESCRIPTION
Correctif d'une maladresse assez stupide de ma part.

La récupération des notes Google doit être cependant revue. "Places" ne permet de récupérer que 5 reviews et pas la totalité sauf moyennant paiement. Des solutions semblent possible avec l'API Business.