### PR TITLE
Evol : ajout de l'attribut "abstract/résumé" sur 2 types de contenus

### DIFF
--- a/WEB-INF/data/types/FicheActu/FicheActu.xml
+++ b/WEB-INF/data/types/FicheActu/FicheActu.xml
@@ -35,7 +35,7 @@
     <field name="videoPrincipale" editor="link" required="false" compactDisplay="false" type="generated.Video" parent="false" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Vidéo principale</label>
     </field>
-    <field name="chapo" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="false" rows="5" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true">
+    <field name="chapo" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="false" rows="5" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true" abstract="true">
       <label xml:lang="fr">Chapo</label>
     </field>
     <!-- Contenu -->

--- a/WEB-INF/data/types/FicheArticle/FicheArticle.xml
+++ b/WEB-INF/data/types/FicheArticle/FicheArticle.xml
@@ -34,7 +34,7 @@
     <field name="videoPrincipale" editor="link" required="false" compactDisplay="false" type="generated.Video" parent="false">
       <label xml:lang="fr">Vidéo principale</label>
     </field>
-    <field name="chapo" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="true" rows="5" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true">
+    <field name="chapo" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="true" rows="5" cols="80" ml="true" wiki="false" html="false" checkHtml="true" descriptionType="tooltip" wysiwygConfigurationId="simple" inline="true" abstract="true">
       <label xml:lang="fr">Chapo</label>
     </field>
     <field name="portletHaut" editor="link" required="false" compactDisplay="false" type="com.jalios.jcms.portlet.PortalElement[]" ml="false" hidden="true" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">


### PR DESCRIPTION
Pour alimenter le champ "Description" dans un flux RSS généré par jPlatform, il faut déclarer comme "abstract" un champ du type de contenu.
Pour le moment on ne cible que les FicheArticle  et FicheActu.
Le champ "chapo" est défini comme "abstract" (résumé).