### PR TITLE
Fix page utile

### DIFF
--- a/WEB-INF/data/types/PageUtileForm/PageUtileForm.xml
+++ b/WEB-INF/data/types/PageUtileForm/PageUtileForm.xml
@@ -13,7 +13,7 @@
       <offLabel xml:lang="en">No</offLabel>
       <offLabel xml:lang="fr">Non</offLabel>
     </field>
-    <field name="motif" editor="enumerate" required="false" compactDisplay="false" type="String" chooser="checkbox" valueList="pasAssezComplet|tropComplique|tropLong" ml="false" descriptionType="tooltip" labelList="L’information n’est pas assez complète|L’information est trop compliquée|Il y a trop à lire" searchable="false" html="false" checkHtml="true">
+    <field name="motif" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
       <label xml:lang="fr">motif</label>
     </field>
     <field name="commentaire" editor="textarea" required="false" compactDisplay="false" type="String" searchable="false" rows="5" cols="80" ml="false" wiki="false" html="false" wysiwygConfigurationId="" checkHtml="false">

--- a/plugins/SoclePlugin/jsp/forms/checkPageUtile.jsp
+++ b/plugins/SoclePlugin/jsp/forms/checkPageUtile.jsp
@@ -65,6 +65,7 @@ if(isOK){
     pageUtileForm.setTitle("Page utile");
     pageUtileForm.setUtile(pageUtile);
     pageUtileForm.setCommentaire(commentaire);
+    pageUtileForm.setEmail(emailReponse);
     pageUtileForm.setIdContenu(id);
     pageUtileForm.setUrl(url);
     pageUtileForm.setAuthor(opAuthor);


### PR DESCRIPTION
Ajout de l'enregistrement de l'adresse email.
Si non renseignée par l'utilisateur ça laisse le champ vide dans le BO.