### PR TITLE
979 - format twitter card large

### DIFF
--- a/jcore/doEmptyHeader.jspf
+++ b/jcore/doEmptyHeader.jspf
@@ -27,7 +27,7 @@
   
   //DEP44 : ajout balise meta pour twiiter card
   if (opengraphEnabled) {
-    jcmsContext.addCustomHeader("<meta name=\"twitter:card\" content=\"summary\" />");
+    jcmsContext.addCustomHeader("<meta name=\"twitter:card\" content=\"summary_large_image\" />");
     if (Util.notEmpty(strDescription)) {
       jcmsContext.addCustomHeader("<meta name=\"twitter:description\" content=\""+ encodeForHTMLAttribute(strDescription) + "\" />");
       jcmsContext.addCustomHeader("<meta property=\"og:description\" content=\""+ encodeForHTMLAttribute(strDescription) + "\" />");


### PR DESCRIPTION
Pour les mêmes meta le format large semble fonctionner sur d'autres sites.
Si cela ne fonctionne toujours pas, alors il faudra regarder ailleurs et comprendre pourquoi ça ne passe pas côté twitter...
Possibilité de blocage réseau ?