### PR TITLE
Fix inclusion des RS bas de page

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/VideoUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/VideoUtils.java
@@ -38,11 +38,13 @@ public final class VideoUtils {
     webappUrl = webappUrl.substring(0, webappUrl.length()-1);
     
     Map<String, String[]> map = new HashMap<>();
+    map.put("autoplay", new String[] { "1" });
     map.put("enablejsapi", new String[] { "1" });
     map.put("frameborder", new String[] { "0" });
     map.put("html5", new String[] { "1" });
     map.put("origin", new String[] { webappUrl });
     map.put("rel", new String[] { "0" });
+    map.put("showinfo", new String[] { "0" });
 
     builtUrl = URLUtils.buildUrl(builtUrl, map);
 


### PR DESCRIPTION
Le "return" semble empêcher l'include du composant "page utile" dans le fichier doFicheArticleFullDisplay.jsp.
En effet si les RS sont désactivés alors le composant page utile est masqué...
Du coup je l'ai remplacé et ça fonctionne bien comme ça.