### PR TITLE
EVOL RS-1780 gabarit "en un clic"

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -494,7 +494,11 @@
         <template name="tuiles1colhome" file="doPortletMiseEnAvantDeContenusBoxOneColumnHome.jsp" usage='box'>
           <label xml:lang="fr">DS44 : gabarit tuiles sur une colonne pour page d'accueil</label>
           <description xml:lang="fr">(ex : "En un clic")</description>
-        </template>        
+        </template>
+        <template name="tuiles1colhomeXSTheme" file="doPortletMiseEnAvantDeContenusBoxOneColumnHomeExtraSmallTheme.jsp" usage='box'>
+          <label xml:lang="fr">DS44 : gabarit tuiles XS avec couleur du thème sur une colonne pour page d'accueil</label>
+          <description xml:lang="fr">(ex : "En un clic")</description>
+        </template>                
         <template name="plusRecherches" file="doPortletMiseEnAvantDeContenusBoxPlusRecherches.jsp" usage='box'>
           <label xml:lang="fr">DS44 : gabarit bloc liste d'éléments simple</label>
           <description xml:lang="fr">(ex : "Contenus les plus recherchés")</description>

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -291,6 +291,7 @@ media.data-template.contact.FicheLieu: /plugins/SoclePlugin/types/FicheLieu/doFi
 media.data-template.tuileHorizontaleDark.Publication: /plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
 media.data-template.tuileHorizontaleDark.ListeDeContenus: /plugins/SoclePlugin/types/ListeDeContenus/doListeDeContenusTuileHorizontale.jsp
 media.data-template.tuileHorizontaleLightSmall.Publication: /plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp?context=dark&size=small
+media.data-template.tuileHorizontaleLightExtraSmall.Publication: /plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp?context=dark&size=extrasmall&colorTheme=true&padding=small
 media.data-template.tuileVerticaleDark.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp
 media.data-template.tuileVerticaleLight.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp?context=dark
 media.data-template.tuileVerticaleGpla.Publication: /plugins/SoclePlugin/jsp/templates/tuileVerticale.jsp?context=gpla

--- a/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileCommon.jsp
@@ -18,11 +18,21 @@ String titleAttr = ""; // code HTML de l'attribut "title"
 String titleValue = ""; // valeur de l'attribut "title"
 String styleContext= Util.notEmpty(request.getParameter("context")) ? "ds44-darkContext" : "";
 boolean isSmall = Util.notEmpty(request.getParameter("size")) ? true : false;
+boolean isExtraSmall = (Util.notEmpty(request.getParameter("size")) && request.getParameter("size").equals("extrasmall")) ? true : false;
+boolean colorTheme = Util.notEmpty(request.getParameter("colorTheme")) ? true : false;
+String paddingVignette = (Util.notEmpty(request.getParameter("padding")) && request.getParameter("padding").equals("small")) ? "ds44--s-padding" : "";
+String styleVignette = "";
 boolean isInSixPanelsContext = Util.notEmpty(request.getParameter("cssSix")) ? true : false;
 boolean isLargeTuile = Util.notEmpty(request.getParameter("largePic")) ? true : false;
 String subTitle = "";
 String location = "";
 boolean isDossier = pub instanceof Dossier;
+
+if(isExtraSmall){
+  styleVignette = "--dim80";
+}else if(isSmall){
+  styleVignette = "--dim110";
+}
    
 /* Le type de contenu "Lien" peut pointer vers une publication ou un site externe 
    Dans le cas d'une pub, si c'est un FileDoc alors on fait le lien direct sur le fichier,

--- a/plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
+++ b/plugins/SoclePlugin/jsp/templates/tuileHorizontale.jsp
@@ -41,10 +41,10 @@ if (Util.isEmpty(urlImage)) {
  
 %>
 
-<section class="ds44-card ds44-js-card ds44-card--horizontal <%=styleContext%> <%= isSmall ? "ds44-tiny-reducedFont" : ""%>">
+<section class="ds44-card ds44-js-card ds44-card--horizontal <%= styleContext %> <%= isSmall ? "ds44-tiny-reducedFont" : "" %>">
     <div class="ds44-flex-container ds44-flex-valign-center">
         <jalios:if predicate="<%= Util.notEmpty(urlImage) %>">
-            <div class="ds44-card__section--horizontal--img<%= isSmall ? "--dim110" : "" %>">
+            <div class="ds44-card__section--horizontal--img<%= styleVignette %> <%= colorTheme ? "ds44-theme" : ""%> <%= paddingVignette %>">
                 <picture class="ds44-container-imgRatio ds44-container-imgRatio--carre">
                     <img class="ds44-imgRatio" src="<%= urlImage %>" alt=''>
                 </picture>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumnHomeExtraSmallTheme.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumnHomeExtraSmallTheme.jsp
@@ -1,0 +1,20 @@
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@ include file='/jcore/doInitPage.jspf' %><%
+%><%@ include file='/jcore/portal/doPortletParams.jspf' %><%
+%><% PortletMiseEnAvantDeContenus box = (PortletMiseEnAvantDeContenus)portlet; %><%
+%>
+
+<section id="en1clic_<%= box.getId() %>" class="ds44-mlr35 ds44-mtb2 ds44-mobile-reduced-mar">
+    <h2 class="h2-like" id="titreEn1Clic_<%= box.getId() %>"><%= box.getTitreVisuel(userLang) %></h2>
+
+	<%@ include file="/types/PortletQueryForeach/doQuery.jspf" %>
+	<%@ include file="/types/PortletQueryForeach/doSort.jspf" %>
+	
+	<%@ include file="/types/PortletQueryForeach/doForeachHeader.jspf" %>
+	
+	   <jalios:media data="<%= itPub %>" template="tuileHorizontaleLightExtraSmall"/>
+	
+	<%@ include file="/types/PortletQueryForeach/doForeachFooter.jspf" %>
+	<%@ include file="/types/PortletQueryForeach/doPager.jspf" %>
+
+</section>


### PR DESCRIPTION
Rajout d'un gabarit pour la portlet de mise en avant de contenu : tuile horizontale + petite et avec possibilité de mettre une couleur de fond.
Sera utilisé sur le site Observatoire.