### PR TITLE
fix : prise en compte de la taille max du nb de résultats

### DIFF
--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrid.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGrid.jsp
@@ -28,7 +28,7 @@ if (Util.notEmpty(collection)) {
 	    <div class="mod--hidden ds44-list swipper-carousel-wrap ds44-posRel ds44-container-large" data-nb-visible-slides="5" data-mobile-only="true">
 		    <div class="swiper-container">
 		        <ul class="swiper-wrapper ds44-list grid-5-small-1 has-gutter-l ds44-carousel-swiper">
-		            <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>">
+		            <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" max="<%= box.getMaxResults() %>">
 		                <li class="swiper-slide">
                             <jalios:media data="<%=itContent %>" template="tuileVerticaleLight"/>
 		                </li>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumn.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxOneColumn.jsp
@@ -10,8 +10,8 @@ if (Util.notEmpty(box.getFirstPublications())) {
 
 <%@ include file="/types/PortletQueryForeach/doQuery.jspf" %>
 <%@ include file="/types/PortletQueryForeach/doSort.jspf" %>
-
 <%
+
 if (Util.notEmpty(collection)) {
     allContents.addAll(collection);
 }
@@ -19,7 +19,7 @@ if (Util.notEmpty(collection)) {
 
 <section id="services1clic_<%= box.getId() %>">
     <p role="heading" aria-level="2" class="ds44-box-heading"><%= box.getTitreVisuel(userLang) %></p>
-    <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>">
+    <jalios:foreach name="itContent" type="Content" collection="<%= allContents %>" max="<%= box.getMaxResults() %>">
         <jalios:media data="<%= (Publication) itContent %>" template="tuileHorizontaleDark"/>
     </jalios:foreach>
 </section>


### PR DESCRIPTION
Permet de prendre en compte la taille max paramétrée dans la portlet.
Evite ainsi les pb d'affichage et de temps de réponse quand la requête renvoie beaucoup de résultats