### PR TITLE
Evol portlet mise avant (RS-1826)

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -6,6 +6,8 @@ channel.favicon: plugins/SoclePlugin/images/favicon/favicon.ico
 
 # Logo du site pour site patrimoniaux
 jcmsplugin.socle.gpla.site.logo: https://design.loire-atlantique.fr/assets/images/logos/logo-grand-patrimoine-blanc.svg
+# Lien sur le logo des sites patrimoniaux (portlet de mise en avant)
+jcmsplugin.socle.gpla.site.url: https://www.loire-atlantique.fr/grand-patrimoine
 
 # ------------------------------------------------------------
 #  Propriétés éditables

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGridIcon.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGridIcon.jsp
@@ -27,7 +27,7 @@ if(Util.notEmpty(box.getLienExterne())) {
                 
     <header class="txtcenter ds44--xl-padding-b ds44-container-large">
       <h2 class="h2-like ds44-dark" id="titreMEA<%= box.getId() %>"><%= box.getTitreVisuel(userLang) %></h2>
-        <a class="ds44-block" title="<%= glp("jcmsplugin.socle.lien.site.nouvelonglet", glp("jcmsplugin.socle.gpla.site")) %>" href="<%= glp("jcmsplugin.socle.gpla.site.url") %>" target="_blank" >       
+        <a class="ds44-block" title="<%= glp("jcmsplugin.socle.lien.site.nouvelonglet", glp("jcmsplugin.socle.gpla.site")) %>" href="<%= channel.getProperty("jcmsplugin.socle.gpla.site.url") %>" target="_blank" >       
 	      <picture>
 	          <img src='<%= channel.getProperty("jcmsplugin.socle.gpla.site.logo") %>' alt='<%= glp("jcmsplugin.socle.gpla.site") %>' class="ds44-logoCard"/>
 	      </picture>

--- a/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGridIcon.jsp
+++ b/plugins/SoclePlugin/types/PortletMiseEnAvantDeContenus/doPortletMiseEnAvantDeContenusBoxGridIcon.jsp
@@ -26,10 +26,12 @@ if(Util.notEmpty(box.getLienExterne())) {
 <section class="ds44-container-fluid ds44-bgDark ds44-bg-patrimoine-sites ds44--xxl-padding-tb">
                 
     <header class="txtcenter ds44--xl-padding-b ds44-container-large">
-      <h2 class="h2-like ds44-dark" id="titreMEA<%= box.getId() %>"><%= box.getTitreVisuel(userLang) %></h2>          
-      <picture>
-          <img src='<%= channel.getProperty("jcmsplugin.socle.gpla.site.logo") %>' alt='<%= glp("jcmsplugin.socle.gpla.site") %>' class="ds44-logoCard"/>
-      </picture>     
+      <h2 class="h2-like ds44-dark" id="titreMEA<%= box.getId() %>"><%= box.getTitreVisuel(userLang) %></h2>
+        <a class="ds44-block" title="<%= glp("jcmsplugin.socle.lien.site.nouvelonglet", glp("jcmsplugin.socle.gpla.site")) %>" href="<%= glp("jcmsplugin.socle.gpla.site.url") %>" target="_blank" >       
+	      <picture>
+	          <img src='<%= channel.getProperty("jcmsplugin.socle.gpla.site.logo") %>' alt='<%= glp("jcmsplugin.socle.gpla.site") %>' class="ds44-logoCard"/>
+	      </picture>
+        </a>     
     </header>
 
     <div class="ds44-mobile-extra-smt"> 


### PR DESCRIPTION
Rajout d'un lien sur le logo "grand patrimoine". Non éditable. Lien pérenne.
Note : ce gabarit n'est utilisé que pour les sites patrimoniaux.