### PR TITLE
evol : affichage alertes (RS-1836)

### DIFF
--- a/plugins/SoclePlugin/jsp/include/includePortletQueryForeachAlert.jsp
+++ b/plugins/SoclePlugin/jsp/include/includePortletQueryForeachAlert.jsp
@@ -4,7 +4,7 @@
 Portlet itPortlet = channel.getData(Portlet.class, channel.getProperty("jcmsplugin.socle.alertpri.id"));
 %>
 
-<jalios:if predicate="<%= Util.notEmpty(itPortlet) && (itPortlet instanceof PortletQueryForeach) %>">
+<jalios:if predicate='<%= Util.notEmpty(itPortlet) && (itPortlet instanceof PortletQueryForeach) && Util.isEmpty(request.getAttribute("isSearchFacetPanel")) %>'>
     <%
     PortletQueryForeach box = (PortletQueryForeach) itPortlet;
     %>


### PR DESCRIPTION
Ne pas afficher l'alerte lorsque le full display est appelé en affichage latéral gauche du moteur à facette.