### PR TITLE
Refacto agenda récup thématiques perso

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -571,7 +571,7 @@ public class InfolocaleEntityUtils {
       
       Integer jsonEventId = Util.toInteger(event.getId().replace("INFOLOC-", ""), -1);
       
-      for (int jsonArrayCounter = 0; jsonArrayCounter <= jsonArray.length(); jsonArrayCounter++) {
+      for (int jsonArrayCounter = 0; jsonArrayCounter < jsonArray.length(); jsonArrayCounter++) {
         JSONObject itJsonObject;
         try {
           itJsonObject = jsonArray.getJSONObject(jsonArrayCounter);

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -854,14 +854,44 @@ public class InfolocaleEntityUtils {
 	 * @return
 	 */
 	private static Map<String, Set<Genre>> getAllThematiquesWithLibelles(String fluxId, String[] lblThematiques, String[] idThematiques) {
-	  Map<String, Set<Genre>> genresWithLabels = new LinkedHashMap<>();
-
+	  
 	  JSONObject objThematiques = RequestManager.getFluxMetadata(fluxId, "thematique_perso");
-    String idLbl = "id";
+	  
+	  Map<String, Set<Genre>> genresWithLabels = new LinkedHashMap<>();
+    String arrayMeta = "arrayMeta";
+    String listMetadata = "listMetadata";
     
     try {
-      JSONObject objListeThematiques = objThematiques.getJSONObject("listMetadata");
-      
+      JSONObject objListeThematiques = objThematiques.getJSONObject(listMetadata);
+      if (objListeThematiques.has(arrayMeta)) {
+        for (int metaCounter = 0; metaCounter <= objListeThematiques.getJSONArray(arrayMeta).length(); metaCounter++) {
+          genresWithLabels.putAll(getGenresWithLabelFromObject(objListeThematiques.getJSONArray(arrayMeta).getJSONObject(metaCounter), lblThematiques, idThematiques));
+        }
+      } else {
+        genresWithLabels = getGenresWithLabelFromObject(objListeThematiques, lblThematiques, idThematiques);
+      }
+    } catch (JSONException e) {
+      LOGGER.warn("Exception sur getAllGenreOfThematiques : "+ e.getMessage());
+    }
+    
+
+    return genresWithLabels;
+	}
+	
+	/**
+	 * Exécute la récupération des genres avec labels liés à leur ID
+	 * @param objListeThematiques
+	 * @param lblThematiques
+	 * @param idThematiques
+	 * @return
+	 */
+	private static Map<String, Set<Genre>> getGenresWithLabelFromObject(JSONObject objListeThematiques, String[] lblThematiques, String[] idThematiques) {
+	  
+	  Map<String, Set<Genre>> genresWithLabels = new LinkedHashMap<>();
+	  
+	  String idLbl = "id";
+	  
+	  try {      
       for(int i = 0 ; i < objListeThematiques.length() ; i++) {
         JSONArray listeThematiques = objListeThematiques.getJSONArray(objListeThematiques.names().getString(i));
         
@@ -884,8 +914,8 @@ public class InfolocaleEntityUtils {
     } catch (JSONException e) {
       LOGGER.warn("Exception sur getAllGenreOfThematiques : "+ e.getMessage());
     }
-
-    return genresWithLabels;
+	  
+	  return genresWithLabels;
 	}
 	
 	 /**

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/InfolocaleEntityUtils.java
@@ -864,7 +864,7 @@ public class InfolocaleEntityUtils {
     try {
       JSONObject objListeThematiques = objThematiques.getJSONObject(listMetadata);
       if (objListeThematiques.has(arrayMeta)) {
-        for (int metaCounter = 0; metaCounter <= objListeThematiques.getJSONArray(arrayMeta).length(); metaCounter++) {
+        for (int metaCounter = 0; metaCounter < objListeThematiques.getJSONArray(arrayMeta).length(); metaCounter++) {
           genresWithLabels.putAll(getGenresWithLabelFromObject(objListeThematiques.getJSONArray(arrayMeta).getJSONObject(metaCounter), lblThematiques, idThematiques));
         }
       } else {

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
@@ -349,7 +349,7 @@ public class RequestManager {
                   else if (Util.isEmpty(metadata) || Util.notEmpty(responseContent)) {
                     fluxData = new JSONObject();
                     if (responseContent.startsWith("[")) {
-                      fluxData.put("listMetadata", new JSONObject(responseContent.replaceFirst("\\[", "").replace("}]}]", "}]}")));
+                      fluxData.put("listMetadata", new JSONObject().put("arrayMeta", new JSONArray(responseContent)));
                     } else {
                       fluxData.put("listMetadata", new JSONObject(responseContent));
                     }


### PR DESCRIPTION
Auparavant, ne récupérait qu'une partie des métadonnées thématiques personnalisées. Le refacto prend également en compte les retours potentiels en jsonarray ou jsonobject (assez incertain jusque-là, les deux cas ont été rencontrés sur l'appel à /meta)