### PR TITLE
hotfix : contenus de type Lien

### DIFF
--- a/plugins/SoclePlugin/types/Lien/doLienFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Lien/doLienFullDisplay.jsp
@@ -1,12 +1,8 @@
 <%@ page contentType="text/html; charset=UTF-8" %><%
-%><%-- This file has been automatically generated. --%><%
-%><%--
-  @Summary: Lien display page
-  @Category: Generated
-  @Author: JCMS Type Processor
-  @Customizable: True
-  @Requestable: True
---%><%
+
+// Empêche l'indexation par les moteurs de recherche.
+request.setAttribute("noindex", true);
+
 %><%@ include file='/jcore/doInitPage.jspf' %><%
 %><% Lien obj = (Lien)request.getAttribute(PortalManager.PORTAL_PUBLICATION); %><%
 %><%@ include file='/front/doFullDisplay.jspf' %>


### PR DESCRIPTION
Empêche l'indexation par les moteur en générant un <meta name="robots" content="noindex, nofollow"/>
L'attribut envoyé est récupéré et traité par le module SEO.