### PR TITLE
Evol moteur de recherche général

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -367,6 +367,12 @@ media.data-template.cardResultFocus.FicheLieu: /plugins/SoclePlugin/jsp/cards/do
 media.data-template.card.FichePublication: /plugins/SoclePlugin/jsp/templates/doFichePublicationTuileHorizontaleGrey.jsp
 media.data-template.card.Show: /plugins/SoclePlugin/jsp/cards/doSpectacleCard.jsp
 
+# Card pour moteur de recherche global
+media.data-template.search.Publication: /plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
+media.template.search.application: /plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
+
+
+
 jcms.resource.tt-card-enabled:false
 channel.sidebar.enabled: false
 channel.topbar.enabled: true

--- a/plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
@@ -1,0 +1,25 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@page import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
+<%@ include file='/jcore/doInitPage.jspf' %><%
+%><%@ page import="com.jalios.jcms.taglib.card.*" %><%
+%><%@ include file='/jcore/media/mediaTemplateInit.jspf' %><%
+%><%
+
+if (data == null) {
+  return;
+}
+
+Publication pub = (Publication) data;
+%>
+
+<section class="ds44-card ds44-js-card ds44-card--contact ds44-bgGray">           
+    <div class="ds44-card__section">            
+        <div class="ds44-innerBoxContainer">
+            <h2 class="h4-like ds44-cardTitle" id="1"><a href="<%= pub.getDisplayUrl(userLocale) %>" class="ds44-card__globalLink"><%= pub.getTitle() %></a></h2>
+            <hr class="mbs" aria-hidden="true"/>
+            <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-tag ds44-docListIco" aria-hidden="true"></i><%= SocleUtils.getTypeLibelle(pub, userLang) %></p>            
+        </div>
+        <i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>
+    </div>
+</section>

--- a/plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
+++ b/plugins/SoclePlugin/jsp/cards/doPublicationCard.jsp
@@ -16,7 +16,7 @@ Publication pub = (Publication) data;
 <section class="ds44-card ds44-js-card ds44-card--contact ds44-bgGray">           
     <div class="ds44-card__section">            
         <div class="ds44-innerBoxContainer">
-            <h2 class="h4-like ds44-cardTitle" id="1"><a href="<%= pub.getDisplayUrl(userLocale) %>" class="ds44-card__globalLink"><%= pub.getTitle() %></a></h2>
+            <h2 class="h4-like ds44-cardTitle"><a href="<%= pub.getDisplayUrl(userLocale) %>" class="ds44-card__globalLink"><%= pub.getTitle() %></a></h2>
             <hr class="mbs" aria-hidden="true"/>
             <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-tag ds44-docListIco" aria-hidden="true"></i><%= SocleUtils.getTypeLibelle(pub, userLang) %></p>            
         </div>

--- a/plugins/SoclePlugin/jsp/facettes/displaySearchResult.jsp
+++ b/plugins/SoclePlugin/jsp/facettes/displaySearchResult.jsp
@@ -47,24 +47,13 @@ jsonObject.addProperty("nb-result-per-page", maxResult);
 jsonObject.addProperty("nb-result", collection.getResultSize());
 
 jsonObject.add("result", jsonArray);
+%>
 
-
-%><jalios:foreach collection="<%= resultSet %>" name="itPub" type="Publication" max='<%= maxResult %>' skip='<%= (pager - 1) * maxResult  %>'><%
-    %><jalios:buffer name="itPubListGabarit"><%
-        %>
-        <section class="ds44-card ds44-js-card ds44-card--contact ds44-bgGray  ">           
-            <div class="ds44-card__section">            
-	            <div class="ds44-innerBoxContainer">
-		            <h2 class="h4-like ds44-cardTitle" id="1"><a href="<%= itPub.getDisplayUrl(userLocale) %>" class="ds44-card__globalLink"><%= itPub.getTitle() %></a></h2>
-		            <hr class="mbs" aria-hidden="true"/>
-		            <p class="ds44-docListElem ds44-mt-std"><i class="icon icon-tag ds44-docListIco" aria-hidden="true"></i><%= SocleUtils.getTypeLibelle(itPub, userLang) %></p>	           
-	            </div>
-	            <i class="icon icon-arrow-right ds44-cardArrow" aria-hidden="true"></i>
-            </div>
-        </section>
-        <%
-    %></jalios:buffer><%
-    %><%     
+<jalios:foreach collection="<%= resultSet %>" name="itPub" type="Publication" max='<%= maxResult %>' skip='<%= (pager - 1) * maxResult  %>'>
+    <jalios:buffer name="itPubListGabarit">
+        <jalios:media data="<%= itPub %>" template="search"/>
+    </jalios:buffer>
+    <%     
      jsonArray.add(SocleUtils.publicationToJsonObject(itPub, itPubListGabarit, null, null));
     %><%
  %></jalios:foreach><%                                    


### PR DESCRIPTION
Nouveau gabarit de tuile pour l'affichage des résultats du moteur de recherche général.
L'utilisation du tag <jalios:media> permet d'avoir un gabarit spécifique pour un type de contenu en cas de besoin.
Sera utilisé pour le site Observatoire.