### PR TITLE
1805 - réajout résultats carte canton manuel

### DIFF
--- a/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
+++ b/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
@@ -29,7 +29,7 @@ Category typeDelieuMisEnAvant_2 = channel.getCategory(box.getTypeDeLieu2());
 %><%
 
 %><%@ include file="/types/PortletQueryForeach/doQuery.jspf" %><%
-
+%><%@ include file="/plugins/SoclePlugin/jsp/facettes/doQuerySpecificCantons.jspf" %><%
 %><%@ include file="/plugins/SoclePlugin/jsp/facettes/doQueryText.jspf" %><%
 %><%@ include file="/plugins/SoclePlugin/jsp/facettes/doQueryCids.jspf" %><%
 %><%@ include file="/plugins/SoclePlugin/jsp/facettes/doQueryGeoloc.jspf" %><%
@@ -37,7 +37,7 @@ Category typeDelieuMisEnAvant_2 = channel.getCategory(box.getTypeDeLieu2());
 
 // Filtre les communes non sectorisées (id ref vide) quand la sectorisation est activée
 // Car en cas de recherche avec sectorisation le filtre sur les commune est désactivé (car une commune peut avoir un lieu en dehors de cette même commune)
-if(Util.notEmpty(collection) && "true".equalsIgnoreCase(request.getParameter("sectorisation"))) {
+if(Util.notEmpty(collection) && "true".equalsIgnoreCase(request.getParameter("sectorisation")) && Util.notEmpty(box.getQueries())) {
   request.setAttribute("communeHorsSectorisation", true);
   QueryHandler qhCommune = new QueryHandler(box.getQueries()[0]);
   Set resultCommuneSet = qhCommune.getResultSet();

--- a/plugins/SoclePlugin/jsp/facettes/doQuerySpecificCanton.jspf
+++ b/plugins/SoclePlugin/jsp/facettes/doQuerySpecificCanton.jspf
@@ -1,0 +1,11 @@
+<%
+//Custom canton : ajouter les fiches lieu associés au canton
+if (Util.notEmpty(session.getAttribute("cantonMapSearch"))) {
+  Publication itPubCanton = (Publication) session.getAttribute("cantonMapSearch");
+  Set<Data> refSet = itPubCanton.getReferrerSet();
+  for (Data itData : refSet) {
+    if (itData instanceof FicheLieu) collection.add((FicheLieu) itData);
+  }
+  session.removeAttribute("cantonMapSearch");
+}
+%>

--- a/plugins/SoclePlugin/types/Canton/doCantonFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Canton/doCantonFullDisplay.jsp
@@ -144,7 +144,7 @@ List<String> remplacants = new ArrayList<String>();
         PortalElement itPortalElem = channel.getData(PortalElement.class, channel.getProperty("jcmsplugin.socle.canton.recherche.portlet.id"));
         %>
         <jalios:if predicate="<%= Util.notEmpty(itPortalElem) %>">
-            <% request.setAttribute("cantonMapSearch", obj); // nécessaire pour afficher des résultats canton. Sera supprimé une fois les éléments de recherche affichés %>
+            <% session.setAttribute("cantonMapSearch", obj); // nécessaire pour afficher des résultats canton. Sera supprimé une fois les éléments de recherche affichés %>
             <jalios:include pub="<%= itPortalElem %>"/>
         </jalios:if>
             


### PR DESCRIPTION
La mécanique avec l'attribut 'canton' ne fonctionne plus. Passage en récupération manuelle en attendant de déterminer ce qui cause soucis en pré-production et en local.
Sectorisation désactivée, attribut "canton" existant et correct, mais aucun résultat ne remonte (pas de passage dans CantonQueryFilter)