### PR TITLE
Evol page carrefour

### DIFF
--- a/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
@@ -66,9 +66,13 @@ String copyright = obj.getCopyright(userLang);
     </section>
 
     <jalios:if predicate="<%= Util.notEmpty(obj.getBottomportlets()) %>">
+        <% request.setAttribute("currentCatSearch", currentCategory.getId());%>
+        <% request.setAttribute("parentCatSearch", currentCategory.getParent().getId());%>
         <jalios:foreach name="itPortlet" array="<%= obj.getBottomportlets() %>" type="com.jalios.jcms.Publication">
             <jalios:include id="<%= itPortlet.getId() %>" />
         </jalios:foreach>
+        <% request.removeAttribute("currentCatSearch"); %>
+        <% request.removeAttribute("parentCatSearch"); %>
     </jalios:if>
 
         

--- a/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesNoFacettesDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletRechercheFacettes/doPortletRechercheFacettesNoFacettesDisplay.jsp
@@ -34,6 +34,11 @@
 	               <input type="hidden" name='<%= "canton" + glp("jcmsplugin.socle.facette.form-element") %>' value='<%= cantonSearch.getCantonCode() %>' data-technical-field />        
 	            </jalios:if>
 	            
+                <jalios:if predicate='<%= Util.notEmpty(request.getAttribute("currentCatSearch")) &&  Util.notEmpty(request.getAttribute("parentCatSearch"))%>'>
+                   <input type="hidden" name='cids' value='<%= request.getAttribute("currentCatSearch") %>' data-technical-field />
+                   <input type="hidden" name='cidBranches' value='<%= request.getAttribute("parentCatSearch") %>' data-technical-field />        
+                </jalios:if>	            
+	            
 	            <input type="hidden" name='<%= "typeDeTuileFicheLieu" + glp("jcmsplugin.socle.facette.form-element") %>' value='<%= obj.getTypeDeTuileFicheLieu() %>' data-technical-field />
 	        
 	            <input type="hidden" name='<%= "facetOperatorUnion" + glp("jcmsplugin.socle.facette.form-element") %>' value='<%= obj.getModeDesFacettes() %>' data-technical-field />


### PR DESCRIPTION
Permet de mettre en bas d'une page carrefour une portlet de recherche à facette dont les résultats s'affinent sur la catégorie courante.