### PR TITLE
Ajout de l'option pager dans la recherche à facettes

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
@@ -1335,6 +1335,8 @@ public final class SocleUtils {
       }
       else if(nameParam.contains("[value]")) {
     	  itNameKey = nameParam.replace("[value]", "");
+      }else if(!nameParam.contains("[")) {
+        itNameKey = nameParam;
       }
       // Enregistre les paramètres dans une map dans un format plus classique pour le serveur
       if(Util.notEmpty(itNameKey) && !skip) {

--- a/WEB-INF/data/types/PortletRechercheFacettes/PortletRechercheFacettes.xml
+++ b/WEB-INF/data/types/PortletRechercheFacettes/PortletRechercheFacettes.xml
@@ -111,6 +111,14 @@
       <offLabel xml:lang="en">No</offLabel>
       <offLabel xml:lang="fr">Non</offLabel>
     </field>
+    <field name="pager" editor="boolean" required="false" compactDisplay="false" type="boolean" default="false" ml="false" descriptionType="text" searchable="false" html="false" checkHtml="true">
+      <label xml:lang="fr">Pager</label>
+      <description xml:lang="fr">&lt;div class="wysiwyg"&gt;&lt;p&gt;Non compaticle avec la carte&lt;/p&gt;&lt;/div&gt;</description>
+      <onLabel xml:lang="en">Yes</onLabel>
+      <onLabel xml:lang="fr">Oui</onLabel>
+      <offLabel xml:lang="en">No</offLabel>
+      <offLabel xml:lang="fr">Non</offLabel>
+    </field>
     <field type="super" />
   </fields>
   <label xml:lang="fr">Portlet Recherche Facettes</label>

--- a/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
+++ b/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
@@ -25,6 +25,10 @@ String typeDeTuileFicheLieu = request.getParameter("typeDeTuileFicheLieu");
 Category typeDelieuMisEnAvant_1 = channel.getCategory(box.getTypeDeLieu());
 Category typeDelieuMisEnAvant_2 = channel.getCategory(box.getTypeDeLieu2());
 
+// Pager
+boolean hasPager = box.getPager();
+Integer pager = getIntParameter("page", 1);
+int maxResult = box.getMaxResults(); 
 
 %><%
 
@@ -76,8 +80,10 @@ if(Util.notEmpty(collection) && "true".equalsIgnoreCase(request.getParameter("af
 }
 
 
-%><%@ include file="/types/PortletQueryForeach/doSort.jspf" %><%
+%>
 
+
+<%@ include file="/types/PortletQueryForeach/doSort.jspf" %><%
 
 // Place les contenu mis en avant en tête de résultat
 if(Util.notEmpty(typeDelieuMisEnAvant_1) || Util.notEmpty(typeDelieuMisEnAvant_2)) {
@@ -121,10 +127,22 @@ if(Util.notEmpty(typeDelieuMisEnAvant_1) || Util.notEmpty(typeDelieuMisEnAvant_2
 JsonArray jsonArray = new JsonArray();
 JsonObject jsonObject = new JsonObject();
 
+// Gestion du pager
+if(hasPager) {
+  jsonObject.addProperty("page-index", pager);
+} else {
+  jsonObject.addProperty("max-result", maxResult);
+}
+
+
 jsonObject.addProperty("nb-result", collection.size());
-jsonObject.addProperty("nb-result-per-page", box.getMaxResults());
-jsonObject.addProperty("max-result", box.getMaxResults());
+jsonObject.addProperty("nb-result-per-page", maxResult);
+
 jsonObject.add("result", jsonArray);
+
+
+
+
 
 // Id unique de la recherche stocké en bdd et généré depuis la jsp displayResultDecodeParams.jsp (null si pas de ré-écriture d'url)
 jsonObject.addProperty("id", request.getParameter("searchId"));
@@ -134,9 +152,11 @@ session.setAttribute("isSearchFacetLink", true);
 
 %><%
 
-%><%@ include file="/types/PortletQueryForeach/doForeachHeader.jspf" %><%
+%>
 
-    %><jalios:buffer name="itPubListGabarit"><%       
+<jalios:foreach collection="<%= collection %>" name="itPub" type="Publication" max='<%= maxResult %>' skip='<%= (pager - 1) * maxResult  %>'>
+
+    <jalios:buffer name="itPubListGabarit"><%       
 	    %><jalios:select><%	        
 	        %><jalios:if predicate="<%= itPub instanceof FicheLieu %>"><%
 	           %><%
@@ -178,6 +198,6 @@ session.setAttribute("isSearchFacetLink", true);
      jsonArray.add(SocleUtils.publicationToJsonObject(itPub, itPubListGabarit, itPubListGabarit, null));
     %><%
                                         
-%><%@ include file="/types/PortletQueryForeach/doForeachFooter.jspf" %><%
+%></jalios:foreach> <%
 request.removeAttribute("tagRootCatId");
 %><%= jsonObject %>

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -48,7 +48,9 @@ if(multilingue){
             <ul class="ds44-list ds44-skiplinks">
                 <li><a href="#content" class="ds44-skiplinks--link"><%= glp("jcmsplugin.socle.skiplinks.content") %></a></li>
                 <li><a href="#open-menu" class="ds44-skiplinks--link"><%= glp("jcmsplugin.socle.skiplinks.menu") %></a></li>
-                <li><a href="#open-search" class="ds44-skiplinks--link"><%= glp("jcmsplugin.socle.skiplinks.search") %></a></li>
+                <jalios:if predicate="<%= displaySearchMenu %>">
+                    <li><a href="#open-search" class="ds44-skiplinks--link"><%= glp("jcmsplugin.socle.skiplinks.search") %></a></li>
+                </jalios:if>
                 <li><a href="<%= channel.getUrl() %>accessibilite" class="ds44-skiplinks--link"><%= glp("jcmsplugin.socle.skiplinks.accessibility") %></a></li>
             </ul>
     


### PR DESCRIPTION
Permet d'avoir un pager dans les recherche à facettes (non testé avec une carte).
Il y a un boolean dans la portlet recherche facette pour activer le pager (oui/non) pour l'utiliser simplement (valeur par défaut : "non").

Et correction d'un bug qui proposait un lien dans les raccourcis d'accessibilité vers la recherche même quand la recherche n'était pas présente sur le site.