### PR TITLE
Evol : ajout de style pour éditeur wysiwyg

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-charteconfig.conf
+++ b/WEB-INF/plugins/SoclePlugin/wysiwyg/configuration-charteconfig.conf
@@ -1,7 +1,7 @@
 {
   'default': {
     /* Modification des css pour le wysiwyg */
-    content_css: '//dev-design.loire-atlantique.fr/css/cd44.css, //design.loire-atlantique.fr/css/icons.css',
+    content_css: '//dev-design.loire-atlantique.fr/css/cd44.css, //dev-design.loire-atlantique.fr/css/icons.css, plugins/SoclePlugin/wysiwyg/wysiwyg.css',
     
     plugins: 'anchor,autolink,charmap,colorpicker,code,codesample,contextmenu,emoticons,fullscreen,hr,image,link,lists,media,nonbreaking,pagebreak,paste,-pastelink,preview,searchreplace,spellchecker,table,textcolor,-jcms,-jabstract,-jcodesample,-jimagehandler,-jinclude,-jmedia,-jmessage,-jlink,-jsmartinsert,-jtoc,-junifiedinsert,-emoji,-mention,-mentionextra,-dsicons',
     

--- a/plugins/SoclePlugin/wysiwyg/wysiwyg.css
+++ b/plugins/SoclePlugin/wysiwyg/wysiwyg.css
@@ -1,0 +1,8 @@
+div.mce-htmlembed-preview {
+	background-color: #E6E6E6 ;
+	border : 1px solid gray;
+	min-height:60px;
+}
+div.mce-htmlembed-preview:before{
+	content: 'Contenu HTML intégré';
+}


### PR DESCRIPTION
- Permet de matérialiser le code HTML inséré via le module "EmbedPlugin", car dans certains cas on ne voir rien dans l'éditeur wysiwyg ce qui peut être perturbant (insertion de script par ex). Comme c'est assez spécifique je préfère ne pas mettre ça dans le DS.
- Correctif lien CSS pour éditeru wysiwyg. On le fait pointer vers le DS de dev qui est toujours + à jour (css+icones).