### PR TITLE
Evol vignettes / format "custom" et "unchanged"

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/SocleUtils.java
@@ -1160,6 +1160,19 @@ public final class SocleUtils {
   public static String getUrlOfFormattedImageDiaporamaVignette(String imagePath) {
     return generateVignette(imagePath, channel.getIntegerProperty("jcmsplugin.socle.image.diaporama.vignette.width", 0), channel.getIntegerProperty("jcmsplugin.socle.image.diaporama.vignette.height", 0)); 
   }
+  
+  /**
+   * Génère une image formattée pour les vignettes dans un format customisé
+   * La largeur est fixe mais la hauteur dépend du ratio de l'image. 
+   * @param imagePath
+   * @return
+   */
+  public static String getUrlOfFormattedImageCustomMobile(String imagePath) {
+    double ratio = SocleUtils.getRatio(imagePath);
+    int imageWidth = channel.getIntegerProperty("jcmsplugin.socle.image.col4.width", 0);
+    int imageHeight = (int)Math.round(imageWidth / ratio);
+    return generateVignette(imagePath, imageWidth, imageHeight); 
+  }  
 
 
 	/**
@@ -2110,4 +2123,18 @@ public final class SocleUtils {
     }
     return false;
   }	
+  
+  /**
+   * Calcule le ratio d'une image afin de générer la vignette au bon ratio 
+   * @param imagePath le chemin de l'image à tester
+   * @return le ratio de l'image
+   */ 
+  public static double getRatio(String imagePath) {
+    double ratio = 0.0;
+    FileDocument file = FileDocument.getFileDocumentFromFilename(imagePath);
+    if(null != file) {
+      ratio = (double)file.getWidth() / (double)file.getHeight();
+    }
+    return ratio;
+  }   
 }

--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -8,6 +8,7 @@
 
   <types>
     <type name="AbstractPortletFacette"></type>
+    <type name="AbonnementMailjet"></type>
     <type name="AccueilAnnuaireAgenda"></type>
     <type name="AccueilDelegation"></type>
     <type name="Action"></type>

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -203,6 +203,7 @@ jcmsplugin.socle.image.carrousel.width: 363
 jcmsplugin.socle.image.carrousel.height: 240
 jcmsplugin.socle.image.enavant.width: 1240
 jcmsplugin.socle.image.enavant.height: 520
+jcmsplugin.socle.image.col4.width: 370
 
 # ------------------------------------------------------------
 #  Wysiwyg

--- a/WEB-INF/tags/figurePicture.tag
+++ b/WEB-INF/tags/figurePicture.tag
@@ -181,6 +181,12 @@ if (format.equals("principale") || format.equals("bandeau") ||format.equals("car
   if (Util.isEmpty(formattedMobilePath)) {
     formattedMobilePath = SocleUtils.getUrlOfFormattedImageCarouselAccueilMobile(image);
   }
+} else if (format.equals("custom") || format.equals("unchanged")){
+  formattedMobilePath = SocleUtils.getUrlOfFormattedImageCustomMobile(imageMobile);
+
+  if (Util.isEmpty(formattedMobilePath)) {
+    formattedMobilePath = SocleUtils.getUrlOfFormattedImageCustomMobile(image);
+  }
 } else {
   // défaut 
   formattedMobilePath = SocleUtils.getUrlOfFormattedImageMobile(imageMobile);


### PR DESCRIPTION
Prise en compte du ratio de l'image initiale pour générer la vignette. La largeur a été fixée à 370px.