### PR TITLE
fix marges PageCarrefour (RS-1782)

### DIFF
--- a/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/PageCarrefour/doPageCarrefourFullDisplay.jsp
@@ -19,7 +19,7 @@ String copyright = obj.getCopyright(userLang);
         
         <ds:titleBanner pub="<%= obj %>" imagePath="<%=imageFile %>" mobileImagePath="<%=imageMobileFile %>" title="<%=title %>" legend="<%=legende %>" copyright="<%=copyright%>" breadcrumb="true"></ds:titleBanner>
 
-        <div class="ds44-inner-container ds44-xl-margin-tb">
+        <div class="ds44-inner-container <%= Util.notEmpty(obj.getChapo(userLang)) || Util.notEmpty(obj.getTopportlets()) ? "ds44-xl-margin-tb" : "" %>">
             <div class="grid-12-small-1">
                 <div class="col-7">
                     <jalios:if predicate="<%= Util.notEmpty(obj.getChapo(userLang)) %>">


### PR DESCRIPTION
Supprime une classe si pas de chapo ou pas de portlet haut.
Utile dans le cas du site Observatoire.