### PR TITLE
1085 - éviter les doublons form page utile

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/PageUtileFormDataController.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/PageUtileFormDataController.java
@@ -1,0 +1,56 @@
+package fr.cg44.plugin.socle.datacontroller;
+
+import java.util.Calendar;
+import java.util.Map;
+
+import com.jalios.jcms.BasicDataController;
+import com.jalios.jcms.Data;
+import com.jalios.jcms.DataController;
+import com.jalios.jcms.Member;
+import com.jalios.jcms.QueryResultSet;
+import com.jalios.jcms.handler.QueryHandler;
+import com.jalios.jcms.plugin.PluginComponent;
+import com.jalios.util.Util;
+
+import generated.PageUtileForm;
+
+public class PageUtileFormDataController extends BasicDataController implements PluginComponent {
+	
+    /**
+     * En cas de création, il faut comparer avec le dernier élément créé.
+     * Si le nouveau et le dernier créé sont identiques en contenus, et créés avec un délai suffisamment court,
+     * il faut annuler l'écriture du contenu
+     */
+    @Override
+    public void beforeWrite(Data data, int op, Member mbr, Map context) {
+        
+        if(op==OP_CREATE){
+             PageUtileForm itForm = (PageUtileForm) data;
+             QueryHandler qh = new QueryHandler();
+             qh.setTypes("PageUtileForm");
+             qh.setSort("cdate");
+             QueryResultSet qrs = qh.getResultSet();
+             PageUtileForm mostRecentForm = (PageUtileForm) qrs.getAsSortedSet().first();
+             Calendar nowCal = Calendar.getInstance();
+             int allowedDifference = channel.getIntegerProperty("jcmsplugin.socle.formpageutile.alloweddelay", 3) * 1000; // prop en millisecondes
+             if (nowCal.getTimeInMillis() - mostRecentForm.getCdate().getTime() > allowedDifference) {
+                 return;
+             }
+             // Il y a très peu de temps entre la création du dernier formulaire et celui que l'on souhaite créer
+             // Il faut vérifier si les contenus sont identiques
+             if (
+                 itForm.getUtile() == mostRecentForm.getUtile()
+                 && itForm.getMotif().equals(mostRecentForm.getMotif())
+                 && Util.notEmpty(itForm.getCommentaire()) ? itForm.getCommentaire().equals(mostRecentForm.getCommentaire()) : Util.isEmpty(mostRecentForm.getCommentaire())
+                 && Util.notEmpty(itForm.getIdContenu()) ? itForm.getIdContenu().equals(mostRecentForm.getIdContenu()) : Util.isEmpty(mostRecentForm.getIdContenu())
+                 && Util.notEmpty(itForm.getUrl()) ? itForm.getUrl().equals(mostRecentForm.getUrl()) : Util.isEmpty(mostRecentForm.getUrl())
+                 && Util.notEmpty(itForm.getEmail()) ? itForm.getEmail().equals(mostRecentForm.getEmail()) : Util.isEmpty(mostRecentForm.getEmail())
+             ) {
+                 // Tous les champs sont identiques ET ils ont été créés très récemment : on doit donc annuler l'écriture du contenu
+                 // pour éviter les doublons
+                 context.put(DataController.DO_NOT_STORE, Boolean.TRUE);
+             }
+        }
+         
+    }
+}

--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -643,6 +643,7 @@
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.CandidatureSpontaneeFormDataController" types="CandidatureSpontaneeForm" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FicheEmploiStageDataController" types="FicheEmploiStage" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FileDocumentDataController" types="FileDocument" />
+    <datacontroller  class="fr.cg44.plugin.socle.datacontroller.PageUtileFormDataController" types="PageUtileForm" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.SoclePortalPolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCityEnginePolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCantonEnginePolicyFilter" />

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -140,6 +140,7 @@ jcmsplugin.socle.form.login.oublie-passe: Forgot your password ?
 jcmsplugin.socle.form.contact-mail.title: Contact form
 jcmsplugin.socle.form.contact-mail.origine: Loire Atlantique Departement
 jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
+jcmsplugin.socle.form.valider-envoi: Valider
 
 # ------------------------------------------------------------
 #  Mail

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -1024,3 +1024,9 @@ jcmsplugin.socle.rgpd.privacyPolicy.text: To learn more, please read our
 jcmsplugin.socle.rgpd.cookie.jsessionid.descr: This cookie is used server-side to manage user session and allow a user-friendly navigation. It is erased at the end of the session or when the browser is closed.
 jcmsplugin.socle.rgpd.cookie.google.descr: We use Google Analytics through Google Tag Manager to collect analytics information about our users
 jcmsplugin.socle.rgpd.cookie.orejime.descr: This cookie is used by our cookie manager to save your preferences.
+
+# ------------------------------------------------------------
+#  Formulaires page utile
+# ------------------------------------------------------------
+
+jcmsplugin.socle.formpageutile.alloweddelay: Page utile : délai en secondes pour les doublons

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -1025,3 +1025,8 @@ jcmsplugin.socle.rgpd.cookie.jsessionid.descr: Ce cookie est utilisé par le ser
 jcmsplugin.socle.rgpd.cookie.google.descr: Nous utilisons Google Analytics par l’intermédiaire de Google Tag Manager pour collecter des informations analytiques sur nos utilisateurs.
 jcmsplugin.socle.rgpd.cookie.orejime.descr: Ce cookie est utilisé par notre gestionnaire de cookies pour mémoriser vos préférences.
 
+# ------------------------------------------------------------
+#  Formulaires page utile
+# ------------------------------------------------------------
+
+jcmsplugin.socle.formpageutile.alloweddelay: Page utile : délai en secondes pour les doublons

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -140,6 +140,7 @@ jcmsplugin.socle.form.login.oublie-passe: Mot de passe oublié ?
 jcmsplugin.socle.form.contact-mail.title: Formulaire de contact
 jcmsplugin.socle.form.contact-mail.origine: Département de Loire Atlantique
 jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
+jcmsplugin.socle.form.valider-envoi: Valider
 
 # ------------------------------------------------------------
 #  Mail

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -783,3 +783,8 @@ jcmsplugin.socle.export.img.filepath:
 jcmsplugin.socle.portlet-twitter.timeout: 5000
 jcmsplugin.socle.portlet-twitter.retry: 3
 
+# ------------------------------------------------------------
+#  Formulaires page utile
+# ------------------------------------------------------------
+
+jcmsplugin.socle.formpageutile.alloweddelay: 3


### PR DESCRIPTION
Il existe déjà en JS un overlay de chargement qui attend la fin de la validation du formulaire (aka. le traitement Java complet)
Donc en théorie, le bouton devrait *déjà* être désactivé au clic. Voir s'il faut ajouter ce comportement pour d'autres contenus (par ex. le formulaire d'envoi de candidature)