### PR TITLE
Lien cookies footer

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -323,6 +323,7 @@ jcmsplugin.socle.ville: City
 jcmsplugin.socle.source: Source
 jcmsplugin.socle.date-actualisation: Actualisé le
 jcmsplugin.socle.voiraussi: Voir aussi
+jcmsplugin.socle.cookies: Cookies
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -324,6 +324,7 @@ jcmsplugin.socle.ville: Ville
 jcmsplugin.socle.source: Source
 jcmsplugin.socle.motscles: Mots clés
 jcmsplugin.socle.voiraussi: Voir aussi
+jcmsplugin.socle.cookies: Cookies
 
 # ------------------------------------------------------------
 #  Header

--- a/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateFooter.jsp
+++ b/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateFooter.jsp
@@ -50,6 +50,11 @@ String nofollow = box.getNavigatePortlet() ? "" : "rel='nofollow'";
                     </jalios:select>
                 </jalios:if>
             </jalios:foreach>
+            
+            <!-- Lien "cookies présent systématiquement pour ouvrir la modale Orejime -->
+            <li class="ds44-footerLink">
+                <a href="#" class="ds44-js-orejime-show" role="button" tabindex="0"><%= glp("jcmsplugin.socle.cookies") %></a>
+            </li>
         </ul>
     </section>
 </jalios:if>

--- a/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateFooter.jsp
+++ b/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateFooter.jsp
@@ -53,7 +53,7 @@ String nofollow = box.getNavigatePortlet() ? "" : "rel='nofollow'";
             
             <!-- Lien "cookies présent systématiquement pour ouvrir la modale Orejime -->
             <li class="ds44-footerLink">
-                <a href="#" class="ds44-js-orejime-show" role="button" tabindex="0"><%= glp("jcmsplugin.socle.cookies") %></a>
+                <a href="javascript:;" class="ds44-js-orejime-show" role="button" tabindex="0" lang="en"><%= glp("jcmsplugin.socle.cookies") %></a>
             </li>
         </ul>
     </section>


### PR DESCRIPTION
Appel de la modale Orejime via un lien "Cookies" présent en dernier élément des liens du footer.
Lien "en dur" car sera systématiquement placé en dernier sur tous les sites.