### PR TITLE
Inscription espace presse (RS-1744)

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/InscriptionPressFormDataController.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/datacontroller/InscriptionPressFormDataController.java
@@ -1,0 +1,151 @@
+package fr.cg44.plugin.socle.datacontroller;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+
+import com.jalios.jcms.BasicDataController;
+import com.jalios.jcms.Channel;
+import com.jalios.jcms.ControllerStatus;
+import com.jalios.jcms.Data;
+import com.jalios.jcms.JcmsUtil;
+import com.jalios.jcms.Member;
+import com.jalios.jcms.context.JcmsContext;
+import com.jalios.jcms.context.JcmsMessage;
+import com.jalios.jcms.context.JcmsMessage.Level;
+import com.jalios.jcms.plugin.PluginComponent;
+import com.jalios.util.StringEncrypter;
+import com.jalios.util.StringEncrypter.EncryptionException;
+import com.jalios.util.URLUtils;
+import com.jalios.util.Util;
+
+import fr.cg44.plugin.socle.MailUtils;
+import fr.cg44.plugin.socle.SocleUtils;
+import generated.InscriptionPressForm;
+
+public class InscriptionPressFormDataController extends BasicDataController implements PluginComponent {
+  private static final Logger LOGGER = Logger.getLogger(InscriptionPressFormDataController.class);
+  private static final Channel channel = Channel.getChannel();
+
+  public ControllerStatus checkIntegrity(Data data) {
+    ControllerStatus status = ControllerStatus.OK;
+    InscriptionPressForm form = (InscriptionPressForm) data;
+    String userLang = channel.getCurrentUserLang();
+    HttpServletRequest req = channel.getCurrentServletRequest();
+    boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
+    
+    boolean isOK = true;
+
+    // Nom
+    if (Util.isEmpty(form.getNom())) {
+      isOK = false;
+      JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.nom")));
+    }
+
+    // Prénom
+    if (Util.isEmpty(form.getPrenom())) {
+     isOK = false;
+     JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.prenom")));
+    }
+
+    // Mail
+    if (Util.isEmpty(form.getMail())) {
+     isOK = false;
+     JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.mail")));
+    }
+    
+    if (Util.notEmpty(form.getMail())) {
+     String regexp = EMAIL_REGEXP;
+     boolean correspond = Pattern.matches(regexp, form.getMail());
+     if (!correspond) {
+      isOK = false;
+      JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.mail")));
+     }
+     
+     /* On vérifie qu'il n'existe pas déjà un membre avec cette adresse mail
+      */
+     if(Util.notEmpty(channel.getMemberFromEmail(form.getMail()))) {
+       isOK = false;
+       JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.form.mail-existe")));
+     }
+    } 
+
+    // Téléphone
+    if (!multilingue && Util.notEmpty(form.getTelephone())) {
+     String regexp = channel.getProperty("jcmsplugin.socle.regex.phone");
+     boolean correspond = Pattern.matches(regexp, form.getTelephone());
+     if (!correspond) {
+      isOK = false;
+      JcmsContext.addMsg(req, new JcmsMessage(Level.WARN, JcmsUtil.glp(userLang, "jcmsplugin.socle.telephone")));
+     }
+   }
+
+    // Formulaire non valide. On value le titre de la messageBox.
+    if(!isOK) {
+      status = new ControllerStatus();
+      req.setAttribute("titreMessageBox",JcmsUtil.glp(userLang, "jcmsplugin.socle.form.invalidfields"));
+    }
+    return status;
+  }
+
+   
+  /* Après enregistrement du formulaire, envoi de mail de confirmation de création de compte 
+   * vers l'adresse mail saisie dans le form
+   * 
+   */
+   public void afterWrite(Data data, int op, Member mbr, @SuppressWarnings("rawtypes") Map context) {
+
+     if (op == OP_CREATE) {
+       InscriptionPressForm form = (InscriptionPressForm) data;
+       HttpServletRequest request = (HttpServletRequest)context.get("request"); 
+       String lienDeConfirmation = genereLien(request);
+       
+       MailUtils.envoiMailDemandeConfirmationCreationCompte(form, form.getMail().trim(), lienDeConfirmation);
+        
+     }
+   }
+   
+   /**
+    * Retourne l'URL de validation de création du compte
+    * @param request
+    * @return 
+    */   
+   private String genereLien(HttpServletRequest request) {
+     String url = "";
+     
+     // Permet de crypter les paramètres dans l'URL envoyée par mail
+     try {
+       StringEncrypter des3Encrypter = new StringEncrypter(StringEncrypter.DESEDE_ENCRYPTION_SCHEME, channel.getProperty("jcmsplugin.socle.newsletter.encrypt.key"));
+
+       // Construction de la map de paramètres à placer dans l'URL
+       Map<String, String[]> parametersMap = SocleUtils.getFacetsParameters(request);
+       
+       // Ajout de la date d'expiration du lien de validation
+       Calendar calendar = Calendar.getInstance();
+       calendar.add(Calendar.HOUR_OF_DAY, Integer.parseInt(channel.getProperty("jcmsplugin.socle.footer.newsletter.expire.heure")));
+       parametersMap.put("expire", new String[]{Long.toString(calendar.getTimeInMillis())});       
+       
+       // Encode les paramètres de la requete  pour la génération du lien de validation
+       Map<String, String[]> parametersEncodeMap = new HashMap<String, String[]>();
+       String decodeParamsQuery = URLUtils.getQueryString(parametersMap);
+       parametersEncodeMap.put("confirm", new String[]{des3Encrypter.encrypt(decodeParamsQuery)});
+
+       // Création du lien de confirmation
+       String redirectUrl = channel.getUrl() + "plugins/SoclePlugin/jsp/portal/inscription/valideInscriptionEspacePresse.jsp";
+       url = URLUtils.buildUrl(redirectUrl, parametersEncodeMap);
+       
+
+     } catch (EncryptionException e) {
+       LOGGER.error("Espace presse : erreur d'encodage de l'URL de confirmation" + e.getMessage());
+     }
+
+     return url;
+   }
+   
+   
+}

--- a/WEB-INF/data/types/InscriptionPressForm/InscriptionPressForm.xml
+++ b/WEB-INF/data/types/InscriptionPressForm/InscriptionPressForm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<type name="InscriptionPressForm" superclass="com.jalios.jcms.Form" formOneSubmit="false" formNotify="true" formAuthor="j_2" formRedirectMode="currentCategory" categoryTab="true" readRightTab="true" updateRightTab="true" templateTab="true" workflowTab="true" advancedTab="true" titleML="true" hbm="true" debatable="false" unitFieldEdition="true" audienced="false" categories="" database="true">
+  <title ml="false">
+    <label xml:lang="fr">Titre</label>
+    <label xml:lang="en">Title</label>
+  </title>
+  <fields>
+    <field name="nom" editor="textfield" required="false" type="String" searchable="true" size="80" compactDisplay="false" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Nom</label>
+      <label xml:lang="en">Name</label>
+    </field>
+    <field name="prenom" editor="textfield" required="false" type="String" searchable="true" size="80" compactDisplay="false" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Prénom</label>
+    </field>
+    <field name="mail" editor="email" required="false" compactDisplay="false" type="String" searchable="false" size="50" maxlength="500" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Courriel</label>
+    </field>  
+    <field name="telephone" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Téléphone</label>
+    </field>
+    <field name="media" editor="textfield" required="false" type="String" searchable="true" size="80" compactDisplay="false" ml="false" descriptionType="tooltip" html="false" checkHtml="false">
+      <label xml:lang="fr">Média</label>
+    </field>
+  </fields>
+  <label xml:lang="fr">Création de compte - espace presse</label>
+</type>
+

--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -49,6 +49,7 @@
     <type name="FicheSAAD"></type>   
     <type name="Help"></type>
     <type name="Horaire"></type>
+    <type name="InscriptionPressForm"><file path="editFormInscriptionPressForm.jsp" /></type>
     <type name="Lien"></type>
     <type name="ListeDeContenus"></type>
     <type name="Magazine"></type>
@@ -663,6 +664,7 @@
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FicheEmploiStageDataController" types="FicheEmploiStage" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.FileDocumentDataController" types="FileDocument" />
     <datacontroller  class="fr.cg44.plugin.socle.datacontroller.PageUtileFormDataController" types="PageUtileForm" />
+    <datacontroller  class="fr.cg44.plugin.socle.datacontroller.InscriptionPressFormDataController" types="InscriptionPressForm" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.SoclePortalPolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCityEnginePolicyFilter" />
     <policyfilter    class="fr.cg44.plugin.socle.policyfilter.PublicationFacetedSearchCantonEnginePolicyFilter" />

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -126,6 +126,7 @@ jcmsplugin.socle.form.exemple.complement-adresse: Example: Surry Hills
 jcmsplugin.socle.form.exemple.codepostal: Example: 2010
 jcmsplugin.socle.form.exemple.types-docs: Arrêté de nomination, inscription sur liste d’aptitude...
 jcmsplugin.socle.form.exemple.formats: Formats : PDF ou DOC, taille max. : 1Mo
+jcmsplugin.socle.form.exemple.type-media: Exemple : Nom journal, radio...
 jcmsplugin.socle.form.error.taille: Un ou plusieurs fichiers ne sont pas valides, merci de les vérifier. Taille maximum des fichiers : 1Mo
 jcmsplugin.socle.form.candidature.mailTo: Email du destinataire des candidatures
 jcmsplugin.socle.form.candidature.titreArticle: Réponse à une offre d'emploi : {0}
@@ -141,6 +142,12 @@ jcmsplugin.socle.form.contact-mail.title: Contact form
 jcmsplugin.socle.form.contact-mail.origine: Loire Atlantique Departement
 jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
 jcmsplugin.socle.form.valider-envoi: Valider
+jcmsplugin.socle.form.inscription-presse.titre: Créer un compte
+jcmsplugin.socle.form.inscription-presse.validation: Votre inscription est en attente. Un courriel de confirmation vient de vous être envoyé.
+jcmsplugin.socle.form.inscription-presse.inscription-succes: Votre inscription est validée. Un courriel contenant votre mot de passe vient de vous être envoyé.
+jcmsplugin.socle.form.inscription-presse.inscription-echec: Une erreur s'est produite lors de votre inscription. Merci de contacter le service presse.
+jcmsplugin.socle.form.inscription-presse.inscription-expire: Le délai de confirmation de votre inscription a expiré. Veuillez vous inscrire à nouveau.
+jcmsplugin.socle.form.mail-existe: Un utilisateur existe déjà avec ce courriel. Merci d'en choisir un autre ou de lancer la procédure de récupération de mot de passe.
 
 # ------------------------------------------------------------
 #  Mail
@@ -152,7 +159,8 @@ jcmsplugin.socle.email.candidature.objet: Réponse à l'offre d'emploi - {0}
 jcmsplugin.socle.email.faq.objet: FAQ
 jcmsplugin.socle.email.pageutile.objet.utile: HELPFUL
 jcmsplugin.socle.email.pageutile.objet.inutile: NOT HELPFUL
-
+jcmsplugin.socle.email.inscription-presse.compte-validation.objet: Demande de validation de création de compte
+jcmsplugin.socle.email.inscription-presse.compte-creation.objet: Compte créé
 
 # ------------------------------------------------------------
 #  Sectorisation
@@ -327,6 +335,7 @@ jcmsplugin.socle.cookies: Cookies
 jcmsplugin.socle.utilisateur-connecte: Connected user: {0}
 jcmsplugin.socle.deconnexion: Disconnect
 jcmsplugin.socle.identifiant: Login
+jcmsplugin.socle.media: Média
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -99,7 +99,6 @@ jcmsplugin.socle.mailjet.contactList: Id liste de contact mailjet (newsletter)
 # Catégorie de classement FileDocument
 jcmsplugin.socle.category.classementfiledoc: ID catégorie de classement FileDocument
 
-
 # ------------------------------------------------------------
 #  Recherche à facettes
 # ------------------------------------------------------------
@@ -127,6 +126,7 @@ jcmsplugin.socle.form.exemple.complement-adresse: Exemple : Résidence Les Tille
 jcmsplugin.socle.form.exemple.codepostal: Exemple : 44000
 jcmsplugin.socle.form.exemple.types-docs: Arrêté de nomination, inscription sur liste d’aptitude...
 jcmsplugin.socle.form.exemple.formats: Formats : PDF ou DOC, taille max. : 1Mo
+jcmsplugin.socle.form.exemple.type-media: Exemple : Nom journal, radio...
 jcmsplugin.socle.form.error.taille: Un ou plusieurs fichiers ne sont pas valides, merci de les vérifier. Taille maximum des fichiers : 1Mo
 jcmsplugin.socle.form.candidature.mailTo: Email du destinataire des candidatures
 jcmsplugin.socle.form.candidature.titreArticle: Réponse à une offre d'emploi : {0}
@@ -142,6 +142,12 @@ jcmsplugin.socle.form.contact-mail.title: Formulaire de contact
 jcmsplugin.socle.form.contact-mail.origine: Département de Loire Atlantique
 jcmsplugin.socle.form.exemple.structure : Exemple : Association Les petits poissons
 jcmsplugin.socle.form.valider-envoi: Valider
+jcmsplugin.socle.form.inscription-presse.titre: Créer un compte
+jcmsplugin.socle.form.inscription-presse.validation: Votre inscription est en attente. Un courriel de confirmation vient de vous être envoyé.
+jcmsplugin.socle.form.inscription-presse.inscription-succes: Votre inscription est validée. Un courriel contenant votre mot de passe vient de vous être envoyé.
+jcmsplugin.socle.form.inscription-presse.inscription-echec: Une erreur s'est produite lors de votre inscription. Merci de contacter le service presse.
+jcmsplugin.socle.form.inscription-presse.inscription-expire: Le délai de confirmation de votre inscription a expiré. Veuillez vous inscrire à nouveau.
+jcmsplugin.socle.form.mail-existe: Un utilisateur existe déjà avec ce courriel. Merci d'en choisir un autre ou de lancer la procédure de récupération de mot de passe.
 
 # ------------------------------------------------------------
 #  Mail
@@ -153,7 +159,8 @@ jcmsplugin.socle.email.candidature.objet: Réponse à l'offre d'emploi - {0}
 jcmsplugin.socle.email.faq.objet: FAQ
 jcmsplugin.socle.email.pageutile.objet.utile: UTILE
 jcmsplugin.socle.email.pageutile.objet.inutile: PAS UTILE
-
+jcmsplugin.socle.email.inscription-presse.compte-validation.objet: Demande de validation de création de compte
+jcmsplugin.socle.email.inscription-presse.compte-creation.objet: Compte créé
 
 # ------------------------------------------------------------
 #  Sectorisation
@@ -328,6 +335,7 @@ jcmsplugin.socle.cookies: Cookies
 jcmsplugin.socle.utilisateur-connecte: Utilisateur connecté : {0}
 jcmsplugin.socle.deconnexion: Déconnexion
 jcmsplugin.socle.identifiant: Identifiant
+jcmsplugin.socle.media: Média
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -409,6 +409,7 @@ jcmsplugin.socle.form.contact.portlet-rgpd.id: c_1304194
 jcmsplugin.socle.form.candidature.portlet-rgpd.id: c_1305481
 jcmsplugin.socle.form.candidature.file.size.max: 1048576
 $jcmsplugin.socle.form.candidature.idArticle: c_1306503
+$jcmsplugin.socle.form.inscription-presse.groupe-presse: aca_11106
 
 # Catégorie racine pour les rayons agenda
 jcmsplugin.socle.rayon.agenda.root.id: c_1301887

--- a/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf
+++ b/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf
@@ -26,7 +26,7 @@ pour pouvoir s'adapter aux contraintes graphiques du DS
   String pageContextWarningMsg = Util.getString(pageContext.getAttribute(JcmsConstants.WARNING_MSG), "");
   String pageContextInfoMsg = Util.getString(pageContext.getAttribute(JcmsConstants.INFORMATION_MSG), "");
   String pageContextSuccessMsg = Util.getString(pageContext.getAttribute(JcmsConstants.SUCCESS_MSG), "");
-
+  
   String tag = "span";
   
   String errorMsg = Util.surroundWithTag(glp(sessionErrorMsg), tag);
@@ -111,7 +111,12 @@ pour pouvoir s'adapter aux contraintes graphiques du DS
   request.getSession().removeAttribute(JcmsConstants.WARNING_MSG);
   request.getSession().removeAttribute(JcmsConstants.INFORMATION_MSG);
   request.getSession().removeAttribute(JcmsConstants.SUCCESS_MSG);
-    
+  
+  request.removeAttribute(JcmsConstants.ERROR_MSG);
+  request.removeAttribute(JcmsConstants.WARNING_MSG);
+  request.removeAttribute(JcmsConstants.INFORMATION_MSG);
+  request.removeAttribute(JcmsConstants.SUCCESS_MSG);
+  
   JcmsContext.removeMessage(request, errorsList);
   JcmsContext.removeMessage(request, warningList);
   JcmsContext.removeMessage(request, infoList);

--- a/plugins/SoclePlugin/jsp/mail/formulaireEspacePresseConfirmationInscriptionTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/mail/formulaireEspacePresseConfirmationInscriptionTemplate.jsp
@@ -1,0 +1,58 @@
+<%@ include file='/jcore/doInitPage.jspf' %>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title><%= glp("jcmsplugin.socle.email.inscription-presse.compte-validation.objet") %></title>
+  
+  <jsp:include page="stylesEmail.jsp" />
+  
+</head>
+
+<body>
+  <style media="all" type="text/css">
+    td {
+      font-family: Arial, Verdana, Geneva, sans-serif;
+      font-size: 16px;
+    }
+  </style>
+  <!-- Wrapper/Container Table: Use a wrapper table to control the width and the background color consistently of your email. Use this approach instead of setting attributes on the body tag. -->
+  <table id="backgroundTable" style="font-size: 16px; background-color: #FFFFFF; margin: 0 auto; line-height:150%;width:800px;max-width:800px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;" width="100%" cellspacing="0" cellpadding="0">
+    <tbody>
+      <tr>
+        <td class="vTop">
+          <!-- Tables are the most common way to format your email consistently. Set your table widths inside cells and in most cases reset cellpadding, cellspacing, and border to zero. Use nested tables as a way to space effectively in your message. -->
+
+          <table class="content" style="line-height:150%;width:600px;max-width:600px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;margin:0 auto;" width="600" cellspacing="0" cellpadding="0" align="center">
+            <tbody>
+              <tr>
+                <td style="background: #fff; color: #000000;" class="vTop">
+                  <table class="mail-body" width="100%" cellpadding="0" style="margin:30px 0;">
+                    <tbody>
+                      <tr>
+                        <td>
+                        <p>Bonjour,</p>
+                        <p>Votre compte sur loire-atlantique.fr est désormais créé.</p>
+                        <p>Votre identifiant est : <%=request.getAttribute("id") %></p>
+                        <p>Votre mot de passe est : <%=request.getAttribute("pwd") %></p>
+                        <p>Cordialement,</p>
+                        <p>L'équipe de loire-atlantique.fr</p>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+
+    </tbody>
+  </table>
+
+</body>
+
+</html>
+
+
+

--- a/plugins/SoclePlugin/jsp/mail/formulaireEspacePresseDemandeConfirmationInscriptionTemplate.jsp
+++ b/plugins/SoclePlugin/jsp/mail/formulaireEspacePresseDemandeConfirmationInscriptionTemplate.jsp
@@ -1,0 +1,66 @@
+<%@ include file='/jcore/doInitPage.jspf' %>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title><%= glp("jcmsplugin.socle.email.inscription-presse.compte-validation.objet") %></title>
+  
+  <jsp:include page="stylesEmail.jsp" />
+  
+</head>
+
+<body>
+  <style media="all" type="text/css">
+    td {
+      font-family: Arial, Verdana, Geneva, sans-serif;
+      font-size: 16px;
+    }
+  </style>
+  <!-- Wrapper/Container Table: Use a wrapper table to control the width and the background color consistently of your email. Use this approach instead of setting attributes on the body tag. -->
+  <table id="backgroundTable" style="font-size: 16px; background-color: #FFFFFF; margin: 0 auto; line-height:150%;width:800px;max-width:800px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;" width="100%" cellspacing="0" cellpadding="0">
+    <tbody>
+      <tr>
+        <td class="vTop">
+          <!-- Tables are the most common way to format your email consistently. Set your table widths inside cells and in most cases reset cellpadding, cellspacing, and border to zero. Use nested tables as a way to space effectively in your message. -->
+
+          <table class="content" style="line-height:150%;width:600px;max-width:600px;min-width:320px;font-family:Arial, Verdana, Geneva, sans-serif;color:#000000;margin:0 auto;" width="600" cellspacing="0" cellpadding="0" align="center">
+            <tbody>
+              <tr>
+                <td style="background: #fff; color: #000000;" class="vTop">
+                  <table class="mail-body" width="100%" cellpadding="0" style="margin:30px 0;">
+                    <tbody>
+                      <tr>
+                        <td>
+                        <p>Bonjour, vous avez demandé la création d'un compte pour accéder à l'espace presse.</p>
+                        <p>Voici les informations que vous avez saisies : </p>
+                        <p>
+                        <%= glp("jcmsplugin.socle.nom") %> : <%=request.getAttribute("nom") %><br>
+                        <%= glp("jcmsplugin.socle.prenom") %> : <%=request.getAttribute("prenom") %><br>
+                        <%= glp("jcmsplugin.socle.mail") %> : <%=request.getAttribute("email") %><br>
+                        <%= glp("jcmsplugin.socle.telephone") %> : <%=request.getAttribute("telephone") %><br>
+                        <% if(Util.notEmpty(request.getAttribute("media"))) { %>
+                          <%= glp("jcmsplugin.socle.media") %> : <%=request.getAttribute("media") %><br>
+                        <% } %>
+                        </p>
+                        <p>Pour confirmer votre inscription, merci de cliquer sur le lien suivant, ou de le recopier dans votre navigateur : </p>
+                        <a href="<%=request.getAttribute("lien") %>"><%=request.getAttribute("lien") %></a>
+
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+
+    </tbody>
+  </table>
+
+</body>
+
+</html>
+
+
+

--- a/plugins/SoclePlugin/jsp/portal/doMessageBoxCustom.jsp
+++ b/plugins/SoclePlugin/jsp/portal/doMessageBoxCustom.jsp
@@ -1,0 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@ include file='/jcore/doInitPage.jspf' %><%
+%><%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
+      

--- a/plugins/SoclePlugin/jsp/portal/inscription/valideInscriptionEspacePresse.jsp
+++ b/plugins/SoclePlugin/jsp/portal/inscription/valideInscriptionEspacePresse.jsp
@@ -1,0 +1,86 @@
+<%@page import="com.jalios.jcms.context.JcmsMessage"%><%
+%><%@page import="fr.cg44.plugin.socle.MailUtils"%><%
+%><%@ include file='/jcore/doInitPage.jspf' %>
+
+<%
+StringEncrypter des3Encrypter = new StringEncrypter(StringEncrypter.DESEDE_ENCRYPTION_SCHEME, channel.getProperty("jcmsplugin.socle.newsletter.encrypt.key"));
+
+// Decode le paramètre "confirm" avec les informations de l'inscription
+Map<String, String[]> params = URLUtils.parseUrlQueryString(des3Encrypter.decrypt(request.getParameter("confirm")));
+
+// Récupération des champs nécessaires à la création du membre
+String nom = Util.getFirst(params.get("nom"));
+String prenom = Util.getFirst(params.get("prenom"));
+String mail = Util.getFirst(params.get("mail"));
+String telephone = Util.getFirst(params.get("telephone"));
+String medium = Util.getFirst(params.get("media"));
+
+// Vérification de la date d'expiration du lien 
+Calendar calendar = Calendar.getInstance();
+calendar.setTimeInMillis(Long.parseLong(Util.getFirst(params.get("expire"))));
+Date currentDate = Calendar.getInstance().getTime();
+
+boolean isExpire = currentDate.after(calendar.getTime());
+
+if(!isExpire){
+    // Création du membre
+    Member opAuthor = channel.getDefaultAdmin();
+    String password = PasswordGenerator.generateRandomPassword(9);
+    
+    Member member = new Member();
+    member.setLogin(mail);
+    member.setName(nom);
+    member.setFirstName(prenom);
+    member.setEmail(mail);
+    member.setPhone(telephone);
+    member.setPassword(password);
+    
+    if(Util.notEmpty(medium)) {
+      member.setJobTitle(medium);
+    }
+    
+    // Ajout au groupe Presse
+    Group groupePresse = channel.getGroup("$jcmsplugin.socle.form.inscription-presse.groupe-presse");
+    if(Util.notEmpty(groupePresse)){
+      member.addGroup(groupePresse);
+    }
+    
+    // Check and perform the update
+    ControllerStatus status = member.checkAndPerformCreate(opAuthor);
+    if (!status.isOK()) {
+      String msg = status.getMessage(opAuthor.getLanguage());
+      logger.error("Impossible de créer le membre suivant dans l'espace presse : " + mail + " / " + msg);
+      jcmsContext.setErrorMsgSession(msg);
+    }
+    else{
+      // Envoi du mail de confirmation à l'utilisateur
+      
+      if(! MailUtils.envoiMailConfirmationCreationCompte(mail, password)){
+        // Erreur d'envoi de mail.
+        jcmsContext.setErrorMsgSession(glp("jcmsplugin.socle.form.inscription-presse.inscription-echec"));
+        logger.error("Impossible d'envoyer le mail de confirmation suite à la création du membre suivant dans l'espace presse : " + mail);
+      }
+      else{
+        jcmsContext.setInfoMsgSession(glp("jcmsplugin.socle.form.inscription-presse.inscription-succes"));
+      }
+      
+    // Envoi du mail de confirmation à l'espace presse
+    }
+    
+}
+else{
+  // ERREUR Lien expiré
+  jcmsContext.setErrorMsgSession(glp("jcmsplugin.socle.form.inscription-presse.inscription-expire"));
+}
+
+
+// Redirection vers espace presse
+
+Publication redirectPub = channel.getPublication("$jcmsplugin.socle.login.pub");
+String redirectUrl = redirectPub.getDisplayUrl(userLocale);
+      
+String url = URLUtils.buildUrl(redirectUrl, request.getParameterMap());
+      
+sendRedirect(url);
+
+%>

--- a/plugins/SoclePlugin/types/InscriptionPressForm/doEditInscriptionPressForm.jsp
+++ b/plugins/SoclePlugin/types/InscriptionPressForm/doEditInscriptionPressForm.jsp
@@ -1,0 +1,137 @@
+<%-- This file has been automatically generated. --%>
+<%--
+  @Summary: InscriptionPressForm content editor
+  @Category: Generated
+  @Author: JCMS Type Processor 
+  @Customizable: True
+  @Requestable: False 
+--%>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ include file='/jcore/doInitPage.jspf' %>
+<% 
+  EditInscriptionPressFormHandler formHandler = (EditInscriptionPressFormHandler)request.getAttribute("formHandler");
+  ServletUtil.backupAttribute(pageContext, "classBeingProcessed");
+  request.setAttribute("classBeingProcessed", generated.InscriptionPressForm.class);
+  
+  boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue", false);
+%>
+
+<%-- Nom ------------------------------------------------------------ --%>
+<% String nomLabel = glp("jcmsplugin.socle.nom"); %>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-nom" class="ds44-formLabel">
+              <span class="ds44-labelTypePlaceholder"><span><%= nomLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-nom" name="nom"
+                class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", nomLabel) %>"
+                required autocomplete="family-name">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", nomLabel) %></span>
+            </button>
+        </div>
+    </div>
+</div>
+ 
+<%-- Prenom ------------------------------------------------------------ --%>
+<% String prenomLabel = glp("jcmsplugin.socle.prenom"); %>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-prenom" class="ds44-formLabel">
+              <span class="ds44-labelTypePlaceholder"><span><%= prenomLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-prenom" name="prenom" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", prenomLabel) %>"
+                 autocomplete="given-name">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", prenomLabel) %></span>
+            </button>
+        </div>
+    </div>
+</div>
+ 
+<%-- Mail ------------------------------------------------------------ --%>
+<% String mailLabel = glp("jcmsplugin.socle.mail"); %>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-mail" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= mailLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="email" id="form-element-mail" name="mail" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", mailLabel) %>"
+                required autocomplete="email" aria-describedby="explanation-form-element-mail">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", mailLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-mail" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.email") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<%-- Telephone ------------------------------------------------------------ --%>
+<%  String telephoneLabel = glp("jcmsplugin.socle.telephone");
+    String telAutocompleteValue = multilingue ? "tel" : "tel-national";
+%>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-telephone" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= telephoneLabel %><sup aria-hidden="true">*</sup></span></span>
+            </label>
+            <input type="text" id="form-element-telephone" name="telephone" class="ds44-inpStd" required autocomplete="<%= telAutocompleteValue %>" aria-describedby="explanation-form-element-telephone">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", telephoneLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-telephone" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.tel") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<%-- media ------------------------------------------------------------ --%>
+<% String mediaLabel = glp("jcmsplugin.socle.media"); %>
+<div class="ds44-mb3">
+    <div class="ds44-form__container">
+        <div class="ds44-posRel">
+            <label for="form-element-media" class="ds44-formLabel">
+                <span class="ds44-labelTypePlaceholder"><span><%= mediaLabel %></span></span>
+            </label>
+            <input type="text" id="form-element-media" name="media" class="ds44-inpStd" aria-describedby="explanation-form-element-media">
+            <button class="ds44-reset" type="button">
+                <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", mediaLabel) %></span>
+            </button>
+        </div>
+        <div class="ds44-field-information" aria-live="polite">
+            <ul class="ds44-field-information-list ds44-list">
+                <li id="explanation-form-element-media" class="ds44-field-information-explanation"><%= glp("jcmsplugin.socle.form.exemple.type-media") %></li>
+            </ul>
+        </div>
+    </div>
+</div>
+ 
+<%
+{ 
+  TreeSet  removedCatSet = new TreeSet(); 
+  Category itRemoveCat = null;
+  request.setAttribute("InscriptionPressForm.removedCatSet", removedCatSet);
+}  
+%>
+
+<button
+    class="jcms-js-submit ds44-btnStd ds44-btn--invert ds44-bntFullw ds44-bntALeft"
+    title="Valider l'envoi de votre demande">
+    <span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.valider") %></span><i
+        class="icon icon-long-arrow-right" aria-hidden="true"></i>
+</button>
+ 
+<jalios:include target="EDIT_PUB_MAINTAB" targetContext="div" />
+<jalios:include jsp="/jcore/doEditExtraData.jsp" />
+

--- a/plugins/SoclePlugin/types/InscriptionPressForm/doEditInscriptionPressForm.jsp
+++ b/plugins/SoclePlugin/types/InscriptionPressForm/doEditInscriptionPressForm.jsp
@@ -43,7 +43,7 @@
               <span class="ds44-labelTypePlaceholder"><span><%= prenomLabel %><sup aria-hidden="true">*</sup></span></span>
             </label>
             <input type="text" id="form-element-prenom" name="prenom" class="ds44-inpStd" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", prenomLabel) %>"
-                 autocomplete="given-name">
+                required autocomplete="given-name">
             <button class="ds44-reset" type="button">
                 <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", prenomLabel) %></span>
             </button>

--- a/plugins/SoclePlugin/types/InscriptionPressForm/editFormInscriptionPressForm.jsp
+++ b/plugins/SoclePlugin/types/InscriptionPressForm/editFormInscriptionPressForm.jsp
@@ -1,0 +1,55 @@
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@ include file='/jcore/doInitPage.jspf' %>
+<% String[] formTitles = JcmsUtil.getLanguageArray(channel.getTypeEntry(InscriptionPressForm.class).getLabelMap()); %>
+<jsp:useBean id='formHandler' scope='page' class='generated.EditInscriptionPressFormHandler'>
+  <jsp:setProperty name='formHandler' property='request' value='<%= request %>'/>
+  <jsp:setProperty name='formHandler' property='response' value='<%= response %>'/>
+  <jsp:setProperty name='formHandler' property='*' />
+  <jsp:setProperty name='formHandler' property='author' value='j_2'/>
+  <jsp:setProperty name='formHandler' property='title' value='<%= formTitles %>'/>
+</jsp:useBean>
+<%
+  if (formHandler.validate()) {
+    return;
+  }
+  boolean formInPortal = jcmsContext.isInFrontOffice(); 
+%>   
+<jalios:if predicate='<%= !formInPortal %>'>
+<%@ include file='/jcore/doHeader.jspf' %>
+</jalios:if>
+
+<jalios:if predicate='<%= formHandler.isOneSubmit() && formHandler.isSubmitted() %>'>
+  <% setWarningMsg(glp("msg.edit.already-one-submit"), request); %>
+</jalios:if>
+
+<% request.setAttribute("titreFormulaire", glp("jcmsplugin.socle.form.inscription-presse.titre")); %>
+<%@ include file='/plugins/SoclePlugin/jsp/forms/doFormHeader.jspf' %>
+
+    <%-- -- FORM -------------------------------------------- --%>
+    <jalios:query name='__memberSet' dataset='<%= channel.getDataSet(Member.class) %>' comparator='<%= Member.getNameComparator() %>'/>
+    <% request.setAttribute("formMemberSet", __memberSet); %>
+    <jalios:query name='__groupSet' dataset='<%= channel.getDataSet(Group.class) %>' comparator='<%= Group.getNameComparator() %>'/>
+    <% request.setAttribute("formGroupSet", __groupSet); %>
+    
+    <%
+    String formAction = "plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp";
+    Publication currentPub = (Publication) request.getAttribute(PortalManager.PORTAL_PUBLICATION);
+    %>
+    <form action='<%= formAction %>' method='post' name='editForm' accept-charset="UTF-8"  enctype="multipart/form-data">
+        
+        <% request.setAttribute("formHandler", formHandler); %>
+        
+        <%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
+        
+        <jsp:include page="doEditInscriptionPressForm.jsp" />
+        
+        <input type='hidden' name='redirect' value='<%= currentPub.getDisplayUrl(userLocale) %>' data-technical-field />
+        <input type='hidden' name='ws' value='<%= formHandler.getWorkspace().getId() %>' data-technical-field />
+        <input type='hidden' name='opCreate' value='<%= glp("ui.com.btn.submit") %>' data-technical-field />
+        <input type="hidden" name="csrftoken" value="<%= HttpUtil.getCSRFToken(request) %>" data-technical-field>
+        <input type="hidden" name="noSendRedirect" value='true' data-technical-field />
+        <input type="hidden" name="id" value='<%= request.getParameter("id") %>' data-technical-field />
+    
+    </form>
+<% request.setAttribute("idPortletBas", channel.getProperty("jcmsplugin.socle.form.contact.portlet-rgpd.id")); %>
+<%@ include file='/plugins/SoclePlugin/jsp/forms/doFormFooter.jspf' %>


### PR DESCRIPTION
Formulaire de demande de création de compte qui sera affiché à droite d'un article.
Principe de double opt-in : la demande déclenche l'envoi d'un mail contenant un lien de confirmation.
Suite confirmation, création du membre, ajout dans un groupe "Presse", attribution d'un mot de passe aléatoire et envoi des crédentiels par mail.
La soumission ne se fait pas en AJAX et ça peut être un point d'amélioration (à débattre).
J'ai fait une JSP "doMessageBox.jsp" pour pouvoir positionner une portlet JSP en tête de la colonne droite de l'article et ainsi afficher certains messages de succes/echec.