### PR TITLE
Fix : récupération ID vidéo

### DIFF
--- a/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
+++ b/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
@@ -39,8 +39,8 @@ if (Util.notEmpty(request.getAttribute("forcedHeight"))) {
     request.setAttribute("hideVideoTitle", null);
   }
 
-String videoId = obj.getUrlVideo().substring(obj.getUrlVideo().indexOf("?v=") + 3); // récupérer l'ID de la vidéo YT
-// le JS se base sur cette ID et va alors forcer cette ID dans l'url de la vidéo. Utiliser un UID va casser l'affichage de la vidéo 
+String videoId = VideoUtils.getYoutubeVideoId(obj.getUrlVideo()); // récupérer l'ID de la vidéo YT
+// le JS se base sur cette ID et va alors forcer cette ID dans l'url de la vidéo. Utiliser un UID va casser l'affichage de la vidéo
 
 %>
 


### PR DESCRIPTION
Utilisation de la méthode utilitaire dédiée car elle permet de récupérer l'id dans des URLs contenant plusieurs paramètres, et ainsi éviter des erreurs dans ce cas de figure.
Ex  : https://www.youtube.com/watch?time_continue=144&v=oS8ycF8ADbc&feature=emb_logo