### PR TITLE
Evol : bouton Home (RS-1925)

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -343,7 +343,7 @@ jcmsplugin.socle.media: Média
 # ------------------------------------------------------------
 #  Header
 # ------------------------------------------------------------
-jcmsplugin.socle.retour.accueil: Back to home
+jcmsplugin.socle.retour.accueil: Back to home page : {0}
 jcmsplugin.socle.menu.ouvrir: Open the main menu
 jcmsplugin.socle.menu.fermer: Close the main menu
 jcmsplugin.socle.menu.retour: Back to the first level of the main menu

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -343,7 +343,7 @@ jcmsplugin.socle.media: Média
 # ------------------------------------------------------------
 #  Header
 # ------------------------------------------------------------
-jcmsplugin.socle.retour.accueil: Retour à l’accueil du site
+jcmsplugin.socle.retour.accueil: Retour à l’accueil du site : {0}
 jcmsplugin.socle.menu.ouvrir: Ouvrir le menu de navigation
 jcmsplugin.socle.menu.fermer: Fermer le menu de navigation
 jcmsplugin.socle.menu.retour: Retour au premier niveau du menu de navigation

--- a/plugins/SoclePlugin/jsp/portal/headerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/headerSection.jsp
@@ -3,6 +3,7 @@
 <%@ include file='/jcore/portal/doPortletParams.jsp' %>
 <%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%>
 <%@ page import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@ page import="fr.cg44.plugin.seo.SEOUtils"%>
 
 
 <%
@@ -30,19 +31,20 @@ boolean multilingue = channel.getBooleanProperty("jcmsplugin.socle.multilingue",
 String changeLang = "";
 String langIcon = "";
 String langLabel = glp("jcmsplugin.socle.multilingue.version.label");
-String langTitle = "";
+String langTitle = glp("jcmsplugin.socle.multilingue.version.title", glp("jcmsplugin.seo.meta-title"));
 String changeLangUrl = "";
+String siteName = SEOUtils.getSiteName();
+boolean isHome = PortalManager.getHomeCategory().equals(currentCategory) ? true : false;
+String altValue = isHome ? siteName : glp("jcmsplugin.socle.retour.accueil", siteName);  
 
 if(multilingue){
 	if(userLang.equals("fr")){
 	  changeLang = "en";
 	  langIcon = "icon-english";
-	  langTitle = glp("jcmsplugin.socle.multilingue.version.title", JcmsUtil.glp("en", "jcmsplugin.socle.nomDuSite"));
 	}
 	else{
 	  changeLang = "fr";
 	  langIcon = "icon-french";
-	  langTitle = glp("jcmsplugin.socle.multilingue.version.title", JcmsUtil.glp("fr", "jcmsplugin.socle.nomDuSite"));
 	}
 	changeLangUrl = LangTag.getChangeUrl(request, changeLang);
 }
@@ -69,7 +71,7 @@ if(multilingue){
                                 <source media='(max-width: 47.9375em)' srcset='<%= channel.getProperty("jcmsplugin.socle.site.src.logomobile") %>'>
                                 <source media='(min-width: 47.9375em)' srcset='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>'>
                             </jalios:if>
-                            <img class='<%= channel.getProperty("jcmsplugin.socle.site.logo.style")%>' src='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>' alt="<%= HttpUtil.encodeForHTMLAttribute(glp("jcmsplugin.socle.retour.accueil")) %> <%=channel.getName() %>" />
+                            <img class='<%= channel.getProperty("jcmsplugin.socle.site.logo.style")%>' src='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>' alt="<%= HttpUtil.encodeForHTMLAttribute(altValue) %>" />
                         </picture>
                     </a>
                 </div>

--- a/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateBreadcrumb.jsp
+++ b/plugins/SoclePlugin/types/PortletNavigate/doPortletNavigateBreadcrumb.jsp
@@ -1,4 +1,5 @@
 <%@page import="fr.cg44.plugin.socle.SocleUtils"%>
+<%@ page import="fr.cg44.plugin.seo.SEOUtils"%>
 <%@ include file='/jcore/doInitPage.jspf' %>
 <%@ include file='/jcore/portal/doPortletParams.jspf' %>
 <%@ include file='/types/PortletNavigate/doInitPortletNavigate.jspf' %>
@@ -49,7 +50,7 @@ String cible="";
 String title = "";
 String textColorStyle = "";
 
-String lblAltTitle = glp("jcmsplugin.socle.retour.accueil");
+String lblAltTitle = glp("jcmsplugin.socle.retour.accueil", SEOUtils.getSiteName());
 
 // texte du breadcrumb clair/sombre
 if(Util.notEmpty(request.getAttribute("textColor"))){
@@ -60,7 +61,7 @@ if(Util.notEmpty(request.getAttribute("textColor"))){
 <nav role="navigation" aria-label='<%=glp("jcmsplugin.socle.breadcrumb.position")%>' class="ds44-hide-mobile">
     <ul class="ds44-list ds44-breadcrumb <%=textColorStyle%>">
         <li class="ds44-breadcrumb_item">
-            <a href="index.jsp" title="<%= lblAltTitle %> <%=channel.getName()%>"><i class="icon icon-home icon--medium" aria-hidden="true"></i><span class="visually-hidden">Accueil</span></a>
+            <a href="index.jsp" title="<%= lblAltTitle %>"><i class="icon icon-home icon--medium" aria-hidden="true"></i><span class="visually-hidden">Accueil</span></a>
         </li>
         
         <jalios:foreach collection="<%= ancestors %>" type="Category" name="itCategory" counter="itCounter">

--- a/plugins/SoclePlugin/types/Webdoc/doWebdocFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Webdoc/doWebdocFullDisplay.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %><%
 %><%@ include file='/jcore/doInitPage.jspf' %><%
+%><%@ page import="fr.cg44.plugin.seo.SEOUtils"%><%
 %><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
 %><% Webdoc obj = (Webdoc)request.getAttribute(PortalManager.PORTAL_PUBLICATION); %><%
 %><% jcmsContext.setPageTitle(obj.getTitle(userLang)); %><%
@@ -24,7 +25,7 @@ String href = Util.notEmpty(obj.getLienRetourInterne()) ? obj.getLienRetourInter
             <div class="ds44-colRight" style="flex: revert;">
                 <a href="index.jsp" class="ds44-logoContainer">
                     <picture class="ds44-logo">  
-                        <img class="" style="margin-top: 15px;" src='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>' alt='<%= HttpUtil.encodeForHTMLAttribute(glp("jcmsplugin.socle.retour.accueil")) %> <%=channel.getName() %>' />
+                        <img class="" style="margin-top: 15px;" src='<%= channel.getProperty("jcmsplugin.socle.site.src.logo") %>' alt='<%= HttpUtil.encodeForHTMLAttribute(glp("jcmsplugin.socle.retour.accueil", SEOUtils.getSiteName())) %>' />
                     </picture>
                 </a>
             </div>


### PR DESCRIPTION
- mettre en place un texte alternatif du logo différent entre la page d'accueil et les autres pages
- impact sur les autres pages renvoyant vers la Home
- refacto car plusieurs propriétés permettent de configurer un nom de site.
- Attention, dépendance avec SEOPlugin.