### PR TITLE
Evol  : amélioration SEO pour les FAQ (RS-1913)

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/plugin.xml
+++ b/WEB-INF/plugins/SoclePlugin/plugin.xml
@@ -725,6 +725,7 @@
     <file path="jsp/portal/retourFacettesListe.jsp" include="EMPTY_HEADER" />
     <file path="jsp/include/includePortletQueryForeachAlert.jsp" include="SOCLE_ALERTE" />
     <file path="jsp/include/logout.jsp" include="SITE_TOPBAR_RIGHT_END" />
+    <file path="jsp/include/addFaqStructuredData.jsp" include="EMPTY_HEADER"/>
   </public-files>
   <webapp-files>
     <file path="types/PortletSelection/doSelection.jspf" />

--- a/plugins/SoclePlugin/jsp/include/addFaqStructuredData.jsp
+++ b/plugins/SoclePlugin/jsp/include/addFaqStructuredData.jsp
@@ -1,0 +1,12 @@
+<%@ page contentType="text/html; charset=UTF-8"%>
+<%@ include file='/jcore/doInitPage.jsp'%>
+
+<%--    Sur les pages de FAQ, ajoute des données structurées au format json qui serviront à l'amélioration SEO
+        https://developers.google.com/search/docs/advanced/structured-data/faqpage
+--%>
+
+<jalios:if predicate='<%= Util.notEmpty(request.getAttribute("jsonFaq")) %>'>
+    <script type="application/ld+json">
+        <%= request.getAttribute("jsonFaq") %>
+    </script>
+</jalios:if>

--- a/plugins/SoclePlugin/types/FaqAccueil/doFaqAccueilFullDisplayContent.jsp
+++ b/plugins/SoclePlugin/types/FaqAccueil/doFaqAccueilFullDisplayContent.jsp
@@ -1,3 +1,4 @@
+<%@ page import="fr.cg44.plugin.socle.SocleUtils" %>
 <%@ page contentType="text/html; charset=UTF-8" %>
 
 
@@ -20,6 +21,7 @@
 					dataset="<%= obj.getLinkIndexedDataSet(FaqEntry.class) %>"
 					comparator="<%=  new custom.CustomEditFaqEntryHandler.OrderComparator() %>"
 					selector="<%= selector %>"/>
+					
 					<jalios:foreach name="itQuestRep" type="FaqEntry" collection='<%= entrySet %>' counter='nbrQuestRep'>
 						<li class='ds44-collapser_element <%= nbrQuestRep > obj.getNombreDeQuestionsAffichees() ? "hidden" : "" %>'>
 							<p role="heading" aria-level="3">
@@ -62,5 +64,11 @@
 				</div>
 			</jalios:if>
 		</div>
+		
+		<%--  Ajout de données structurées json pour SEO. Elles seront affichées dans le <head>
+		      via une target pointant sur addFaqStructuredData.jsp --%>
+		<jalios:if predicate='<%= Util.notEmpty(entrySet) %>'>
+		  <% request.setAttribute("jsonFaq", SocleUtils.faqToJson(entrySet, userLang)); %>
+		</jalios:if>
 
 


### PR DESCRIPTION
Ajout de données structurées au format JSON sur les pages de FAQ.
Les données sont constituées dans le full display des FAQ puis envoyées sous forme d'attribut pour être affichées dans le "head" via une target.