### PR TITLE
2030 - transfert activités vers missions fiche emploi stage

### DIFF
--- a/WEB-INF/data/types/FicheEmploiStage/FicheEmploiStage.xml
+++ b/WEB-INF/data/types/FicheEmploiStage/FicheEmploiStage.xml
@@ -52,7 +52,7 @@
     <field name="domainesMetiers" editor="category" required="false" compactDisplay="false" tab="mission" type="java.util.TreeSet" chooser="tree" exclusive="false" root="$jcmsplugin.socle.emploiStage.domainesMetiers" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Domaines métiers</label>
     </field>
-    <field name="activites" editor="wysiwyg" required="true" compactDisplay="false" tab="activites" type="String" searchable="true" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" inline="true">
+    <field name="activites" editor="wysiwyg" required="false" compactDisplay="false" tab="activites" type="String" searchable="true" rows="16" cols="100" ml="false" checkHtml="true" inline="true" hidden="true" descriptionType="tooltip" html="false">
       <label xml:lang="fr">Activités</label>
     </field>
     <field name="filiere" editor="category" required="false" compactDisplay="false" tab="profil_souhaite" type="java.util.TreeSet" chooser="tree" exclusive="false" root="$jcmsplugin.socle.emploiStage.filiere.root">

--- a/WEB-INF/data/types/FicheEmploiStage/FicheEmploiStage.xml
+++ b/WEB-INF/data/types/FicheEmploiStage/FicheEmploiStage.xml
@@ -52,7 +52,7 @@
     <field name="domainesMetiers" editor="category" required="false" compactDisplay="false" tab="mission" type="java.util.TreeSet" chooser="tree" exclusive="false" root="$jcmsplugin.socle.emploiStage.domainesMetiers" ml="false" descriptionType="tooltip" searchable="false" html="false" checkHtml="true">
       <label xml:lang="fr">Domaines métiers</label>
     </field>
-    <field name="activites" editor="wysiwyg" required="false" compactDisplay="false" tab="activites" type="String" searchable="true" rows="16" cols="100" ml="false" checkHtml="true" inline="true" hidden="true" descriptionType="tooltip" html="false">
+    <field name="activites" editor="wysiwyg" required="false" compactDisplay="false" type="String" searchable="true" rows="16" cols="100" ml="false" checkHtml="true" inline="true" hidden="true" descriptionType="tooltip" html="false">
       <label xml:lang="fr">Activités</label>
     </field>
     <field name="filiere" editor="category" required="false" compactDisplay="false" tab="profil_souhaite" type="java.util.TreeSet" chooser="tree" exclusive="false" root="$jcmsplugin.socle.emploiStage.filiere.root">
@@ -77,7 +77,7 @@
     <field name="connaissancesEtExperiences" editor="wysiwyg" required="false" compactDisplay="false" tab="competences_attendues" type="String" searchable="false" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" inline="true">
       <label xml:lang="fr">Vous êtes fait·e pour le poste si...</label>
     </field>
-    <field name="conditionsARemplir" editor="wysiwyg" required="false" compactDisplay="false" tab="competences_attendues" type="String" searchable="false" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" inline="true">
+    <field name="conditionsARemplir" editor="wysiwyg" required="false" compactDisplay="false" tab="competences_attendues" type="String" searchable="false" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" hidden="true" inline="true">
       <label xml:lang="fr">Conditions à remplir</label>
     </field>
     <field name="specificitesDuPoste" editor="wysiwyg" required="false" compactDisplay="false" tab="competences_attendues" type="String" searchable="false" rows="16" cols="100" ml="false" wysiwygConfigurationId="" checkHtml="true" inline="true">
@@ -144,9 +144,6 @@
     </field>
   </fields>
   <tabs>
-    <tab id="activites">
-      <label xml:lang="fr">Activités</label>
-    </tab>
     <tab id="classement_et_navigation">
       <label xml:lang="fr">Classement et navigation</label>
     </tab>

--- a/plugins/SoclePlugin/jsp/scripts/ficheEmploiStageActiviteToFuturesMissions.jsp
+++ b/plugins/SoclePlugin/jsp/scripts/ficheEmploiStageActiviteToFuturesMissions.jsp
@@ -4,22 +4,23 @@
 <jalios:select>
 	<jalios:if predicate="<%= Util.isEmpty(loggedMember) || !loggedMember.isAdmin() %>">
 	    <h2>Page accessible uniquement aux administateurs.</h2>
-	    
-	    <p><a href="<%= channel.getUrl() %>">Retour à l'accueil</a></p>
 	</jalios:if>
 	
 	<jalios:default>
-	   <h1>Transfert du contenu du champ "Activités" vers le champ "Futures missions" pour les contenus Fiche Emploi Stage</h1>
+	   <h1>Màj des champs "Missions" et "Vous êtes fait pour le poste si" pour les contenus Fiche Emploi Stage</h1>
 	
 	   <%
 	   TreeSet<FicheEmploiStage> allFiches = channel.getAllDataSet(FicheEmploiStage.class);
 	   for (FicheEmploiStage itFiche : allFiches) {
 		   FicheEmploiStage ficheClone = (FicheEmploiStage) itFiche.getUpdateInstance();
-		   ficheClone.setMissions(ficheClone.getActivites(userLang));
-		   ficheClone.checkAndPerformUpdate(loggedMember);
+		   ficheClone.setMissions(ficheClone.getMissions(userLang) + ficheClone.getActivites(userLang));
+		   ficheClone.setConnaissancesEtExperiences(ficheClone.getConnaissancesEtExperiences(userLang) + ficheClone.getConditionsARemplir(userLang));
+		   ficheClone.performUpdate(loggedMember);
 	   }
 	   %>
 	   
 	   <p>Les contenus ont été mis à jour.</p>
 	</jalios:default>
 </jalios:select>
+
+<p><a href="<%= channel.getUrl() %>">Retour à l'accueil</a></p>

--- a/plugins/SoclePlugin/jsp/scripts/ficheEmploiStageActiviteToFuturesMissions.jsp
+++ b/plugins/SoclePlugin/jsp/scripts/ficheEmploiStageActiviteToFuturesMissions.jsp
@@ -1,0 +1,25 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ include file='/jcore/doInitPage.jspf' %>
+
+<jalios:select>
+	<jalios:if predicate="<%= Util.isEmpty(loggedMember) || !loggedMember.isAdmin() %>">
+	    <h2>Page accessible uniquement aux administateurs.</h2>
+	    
+	    <p><a href="<%= channel.getUrl() %>">Retour à l'accueil</a></p>
+	</jalios:if>
+	
+	<jalios:default>
+	   <h1>Transfert du contenu du champ "Activités" vers le champ "Futures missions" pour les contenus Fiche Emploi Stage</h1>
+	
+	   <%
+	   TreeSet<FicheEmploiStage> allFiches = channel.getAllDataSet(FicheEmploiStage.class);
+	   for (FicheEmploiStage itFiche : allFiches) {
+		   FicheEmploiStage ficheClone = (FicheEmploiStage) itFiche.getUpdateInstance();
+		   ficheClone.setMissions(ficheClone.getActivites(userLang));
+		   ficheClone.checkAndPerformUpdate(loggedMember);
+	   }
+	   %>
+	   
+	   <p>Les contenus ont été mis à jour.</p>
+	</jalios:default>
+</jalios:select>

--- a/plugins/SoclePlugin/types/FicheEmploiStage/doFicheEmploiStageFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheEmploiStage/doFicheEmploiStageFullDisplay.jsp
@@ -178,16 +178,6 @@ boolean afficherMentions = !obj.getMasquerMentions();
             </div>
         </section>
         
-        <%-- Activités --%>
-        <section id="blocactivites" class="ds44-contenuArticle">
-            <div class="ds44-inner-container ds44-mtb3">
-                <div class="ds44-grid12-offset-2">
-                    <h3 id="titreblocactivites"><%= glp("jcmsplugin.socle.ficheemploi.label.activites") %></h3>
-                    <jalios:wysiwyg><%= obj.getActivites() %></jalios:wysiwyg>
-                </div>
-            </div>
-        </section>
-        
         <%-- Compétences attendues --%>
         <jalios:if predicate="<%= Util.notEmpty(obj.getConnaissancesEtExperiences()) %>">
             <section id="bloccompetencesattendues" class="ds44-contenuArticle">


### PR DESCRIPTION
Etape 1. La seconde étape supprimera le script et le champ "Activités"