### PR TITLE
Fix appels api

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
@@ -125,7 +125,7 @@ public class ApiUtil {
       
       try {
         
-        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForURL(url), token);
+        CloseableHttpResponse response = ApiUtil.createGetConnection(url, token);
         
         if (Util.isEmpty(response)) {
             LOGGER.warn("Method getJsonObjectFromApi => pas de réponse HTTP");
@@ -168,7 +168,7 @@ public class ApiUtil {
       
       try {
         
-        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForURL(url), token);
+        CloseableHttpResponse response = ApiUtil.createGetConnection(url, token);
         
         if (Util.isEmpty(response)) {
             LOGGER.warn("Method getJsonArrayFromApi => pas de réponse HTTP");

--- a/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
@@ -125,7 +125,7 @@ public class ApiUtil {
       
       try {
         
-        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForHTML(url), token);
+        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForURL(url), token);
         
         if (Util.isEmpty(response)) {
             LOGGER.warn("Method getJsonObjectFromApi => pas de réponse HTTP");
@@ -168,7 +168,7 @@ public class ApiUtil {
       
       try {
         
-        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForHTML(url), token);
+        CloseableHttpResponse response = ApiUtil.createGetConnection(HttpUtil.encodeForURL(url), token);
         
         if (Util.isEmpty(response)) {
             LOGGER.warn("Method getJsonArrayFromApi => pas de réponse HTTP");


### PR DESCRIPTION
L'encodage de toute l'URL pose problème dans certains cas. Si besoin il faudra encoder en amont les éventuels paramètres.