### PR TITLE
2037 - Fix regression display sous-titre

### DIFF
--- a/plugins/SoclePlugin/types/AccueilAnnuaireAgenda/doAccueilAnnuaireAgenda_Agenda.jsp
+++ b/plugins/SoclePlugin/types/AccueilAnnuaireAgenda/doAccueilAnnuaireAgenda_Agenda.jsp
@@ -21,7 +21,7 @@
                     </jalios:if>
                     <jalios:if predicate="<%= Util.notEmpty(obj.getIntroSelectionAgenda()) %>">
 	                    <p class="ds44-component-chapo ds44-centeredBlock">
-	                        <jalios:wysiwyg><%= obj.getIntroSelectionAgenda(userLang) %></jalios:wysiwyg>
+	                       <%= HtmlUtil.html2text(obj.getIntroSelectionAgenda(userLang)) %>
 	                    </p>
                     </jalios:if>
                 </header>

--- a/plugins/SoclePlugin/types/AccueilDelegation/doAccueilDelegationFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/AccueilDelegation/doAccueilDelegationFullDisplay.jsp
@@ -20,7 +20,7 @@
                     <h2 class="h2-like center"><%= obj.getTitreAnnuaire() %></h2>
                 </jalios:if>
                 <jalios:if predicate="<%= Util.notEmpty(obj.getIntroAnnuaire()) %>">
-                    <p class="ds44-component-chapo ds44-centeredBlock"><jalios:wysiwyg><%= obj.getIntroAnnuaire() %></jalios:wysiwyg></p>
+                    <p class="ds44-component-chapo ds44-centeredBlock"><%= HtmlUtil.html2text(obj.getIntroAnnuaire()) %>
                 </jalios:if>
                 <jalios:if predicate="<%= Util.notEmpty(obj.getPortletRecherche()) %>">
                     <jalios:include pub="<%= obj.getPortletRecherche() %>"/>

--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
@@ -15,7 +15,7 @@
             
             <jalios:if predicate="<%= Util.notEmpty(sousTitreBloc) %>">
                 <p class="ds44-component-chapo ds44-centeredBlock">
-                    <jalios:wysiwyg><%= sousTitreBloc %></jalios:wysiwyg>
+                    <%= HtmlUtil.html2text(sousTitreBloc) %>
                 </p>
             </jalios:if>
         </header>

--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselSliderSixPanels.jsp
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselSliderSixPanels.jsp
@@ -25,7 +25,7 @@ String sliderAmounts = "1";
             
             <jalios:if predicate="<%= Util.notEmpty(sousTitreBloc) %>">
                 <p class="ds44-component-chapo ds44-centeredBlock">
-                    <jalios:wysiwyg><%= sousTitreBloc %></jalios:wysiwyg>
+                    <%= HtmlUtil.html2text(sousTitreBloc) %>
                 </p>
             </jalios:if>
         </header>

--- a/plugins/SoclePlugin/types/PortletConteneurAgenda/doPortletConteneurAgendaBoxDisplay.jsp
+++ b/plugins/SoclePlugin/types/PortletConteneurAgenda/doPortletConteneurAgendaBoxDisplay.jsp
@@ -19,7 +19,7 @@ request.setAttribute("isInPortletConteneur", true);
 	            
 	            <jalios:if predicate="<%= Util.notEmpty(sousTitreBloc) %>">
 	                <p class="ds44-component-chapo ds44-centeredBlock">
-	                    <jalios:wysiwyg><%= sousTitreBloc %></jalios:wysiwyg>
+	                    <%= HtmlUtil.html2text(sousTitreBloc) %>
 	                </p>
 	            </jalios:if>
 	        </header>


### PR DESCRIPTION
Le <jalios:wysiwyg> générait un div, qui ne peut être placé dans un p. Par conséquent, le div était placé à côté et le CSS via style ne pouvait plus être appliqué
Passage en ligne unique