### PR TITLE
1974 - Overlay GRPD vidéo - désactivation chapitrage

### DIFF
--- a/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/en.prop
@@ -339,6 +339,9 @@ jcmsplugin.socle.utilisateur-connecte: Connected user: {0}
 jcmsplugin.socle.deconnexion: Disconnect
 jcmsplugin.socle.identifiant: Login
 jcmsplugin.socle.media: Média
+jcmsplugin.socle.videodesactivee: Video deactivated
+jcmsplugin.socle.devezaccepterdepotcookie: You must accept streaming cookies to play the video.
+jcmsplugin.socle.acceptercookies: Accept cookies
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/languages/fr.prop
@@ -339,6 +339,9 @@ jcmsplugin.socle.utilisateur-connecte: Utilisateur connecté : {0}
 jcmsplugin.socle.deconnexion: Déconnexion
 jcmsplugin.socle.identifiant: Identifiant
 jcmsplugin.socle.media: Média
+jcmsplugin.socle.videodesactivee: Vidéo désactivée
+jcmsplugin.socle.devezaccepterdepotcookie: Vous devez accepter le dépôt de <span lang="en">cookies</span> de <span lang="en">streaming</span> pour lire la vidéo.
+jcmsplugin.socle.acceptercookies: Accepter les <span lang="en">cookies</span>
 
 # ------------------------------------------------------------
 #  Header

--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -116,10 +116,11 @@ String urlVideo = "";
 String fichierTranscriptVideo = "";
 String typeFichierTranscript = "";
 String tailleFichierTranscript = "";
+String videoId = "";
 if(Util.notEmpty(video)) {
     titreVideo = video.getTitle();
     urlVideo = Util.decodeUrl(VideoUtils.buildYoutubeUrl(video.getUrlVideo()));
-    
+    videoId = VideoUtils.getYoutubeVideoId(video.getUrlVideo()); // récupérer l'ID de la vidéo YT
     // Récupération des infos du fichier de transcription
     if(Util.notEmpty(video.getFichierTranscript(userLang))){
         fichierTranscriptVideo = video.getFichierTranscript(userLang).getDownloadUrl();
@@ -158,25 +159,42 @@ if(Util.notEmpty(video)) {
     </div>
 </div>
 <jalios:select>
-    <jalios:if predicate="<%=Util.notEmpty(urlVideo)%>">
-        <div class="ds44-img50">
-            <div class="ds44-inner-container">
-                <div class="ds44-grid12-offset-1">
-                    <iframe title='<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.acceder", titreVideo)) %>' style="width: 100%; height: 480px; border: none;" src="<%= urlVideo %>" allowfullscreen></iframe>
-                    <jalios:if predicate="<%=Util.notEmpty(fichierTranscriptVideo)%>">
-                        <p><a href="<%= fichierTranscriptVideo %>" target="_blank" title="<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript.title", titreVideo,typeFichierTranscript,tailleFichierTranscript)) %>"><%= JcmsUtil.glp(userLang,"jcmsplugin.socle.video.telecharger-transcript.label") %></a></p>
-                    </jalios:if>
-                </div>
+   <jalios:if predicate="<%=Util.notEmpty(urlVideo)%>">
+      <div class="ds44-img50">
+         <div class="ds44-inner-container">
+            <div class="ds44-grid12-offset-1">
+               <!-- <div class="ds44-js-youtube-video" data-video-id="<%= videoId %>"> -->
+               <div>
+                  <div class="ds44-cookie-overlay-container">
+                     <div class="ds44-video-container">
+                        <iframe title='<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.acceder", titreVideo)) %>' style="width: 100%; height: 480px; border: none;" src="<%= urlVideo %>" allowfullscreen></iframe>
+                     </div>
+                     <div class="ds44-media-overlay" style="display: none;">
+		               <div class="ds44-msg-media-desactive">
+		                  <p><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.videodesactivee") %></p>
+		                  <p><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.devezaccepterdepotcookie") %></p>
+		                  <button class="ds44-btnStd ds44-btn--contextual" data-consent="accept-streaming-cookie">
+		                  <span class="ds44-btnInnerText"><%= JcmsUtil.glp(userLang, "jcmsplugin.socle.acceptercookies") %><i class="icon icon-long-arrow-right" aria-hidden="true"></i>
+		                  </span>
+		                  </button>
+		               </div>
+		            </div>
+                  </div>
+                  <jalios:if predicate="<%=Util.notEmpty(fichierTranscriptVideo)%>">
+                     <p><a href="<%= fichierTranscriptVideo %>" target="_blank" title="<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.telecharger-transcript.title", titreVideo,typeFichierTranscript,tailleFichierTranscript)) %>"><%= JcmsUtil.glp(userLang,"jcmsplugin.socle.video.telecharger-transcript.label") %></a></p>
+                  </jalios:if>
+               </div>
             </div>
-        </div>
-    </jalios:if>
-    <jalios:if predicate="<%=Util.notEmpty(imagePath)%>">
-        <div class="ds44-img50">
-            <div class="ds44-inner-container">
-                <div class="ds44-grid12-offset-1">
-                    <ds:figurePicture pub="<%= pub %>" imgCss="ds44-w100 ds44-imgRatio" pictureCss="ds44-legendeContainer ds44-container-imgRatio" format="principale" image="<%= imagePath %>" imageMobile="<%= mobileImagePath %>" alt="<%= alt %>" copyright="<%= copyright %>" legend="<%= legend %>"/>
-                </div>
+         </div>
+      </div>
+   </jalios:if>
+   <jalios:if predicate="<%=Util.notEmpty(imagePath)%>">
+      <div class="ds44-img50">
+         <div class="ds44-inner-container">
+            <div class="ds44-grid12-offset-1">
+               <ds:figurePicture pub="<%= pub %>" imgCss="ds44-w100 ds44-imgRatio" pictureCss="ds44-legendeContainer ds44-container-imgRatio" format="principale" image="<%= imagePath %>" imageMobile="<%= mobileImagePath %>" alt="<%= alt %>" copyright="<%= copyright %>" legend="<%= legend %>"/>
             </div>
-        </div>
-    </jalios:if>
+         </div>
+      </div>
+   </jalios:if>
 </jalios:select>

--- a/plugins/SoclePlugin/jsp/rgpd/orejimeConfig.jsp
+++ b/plugins/SoclePlugin/jsp/rgpd/orejimeConfig.jsp
@@ -98,6 +98,24 @@
                 purposes: ['analytics']
             },
             {
+                name: 'streaming-video',
+                title: 'Streaming vidéo',
+                purposes: ['streamingvideo'],
+                optOut: false,
+                required: false,
+                onlyOnce: false,
+                callback: function(consent, app){
+                    // This is an example callback function.
+                    const overlays = document.querySelectorAll('.ds44-media-overlay');
+                    consent ? overlays.forEach((overlay) => {
+                        overlay.style.display = "none";
+                    }) : overlays.forEach((overlay) => {
+                        overlay.style.display = "table";
+                    });
+                    console.log("User consent for app " + app.name + ": consent=" + consent)
+                },
+            },
+            {
                 name: 'jsessionid',
                 title: 'JSESSIONID',
                 purposes: [],

--- a/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
+++ b/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
@@ -51,11 +51,23 @@ String videoId = VideoUtils.getYoutubeVideoId(obj.getUrlVideo()); // récupérer
     <jalios:wysiwyg><%= chapoVideo %></jalios:wysiwyg>
 </jalios:if>
 
-<div class="ds44-js-youtube-video" data-video-id="<%= videoId %>">
-    <div class="ds44-video-container">
-		
-		<iframe title='<%= HttpUtil.encodeForHTML(glp("jcmsplugin.socle.video.acceder", titleVideo)) %>' id="<%=uniqueIDiframe%>" class="ds44-hiddenPrint ds44-video-item" style="width: 100%; height: <%= heightIframe %>; border: none;" src="<%=urlVideo%>" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+<!-- <div class="ds44-js-youtube-video" data-video-id="<%= videoId %>"> -->
+<div>
+    <div class="ds44-cookie-overlay-container">
+	    <div class="ds44-video-container">
 			
+			<iframe title='<%= HttpUtil.encodeForHTML(glp("jcmsplugin.socle.video.acceder", titleVideo)) %>' id="<%=uniqueIDiframe%>" class="ds44-hiddenPrint ds44-video-item" style="width: 100%; height: <%= heightIframe %>; border: none;" src="<%=urlVideo%>" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+			<div class="ds44-media-overlay" style="display: none;">
+		        <div class="ds44-msg-media-desactive">
+		            <p><%= glp("jcmsplugin.socle.videodesactivee") %></p>
+		            <p><%= glp("jcmsplugin.socle.devezaccepterdepotcookie") %></p>
+		            <button class="ds44-btnStd ds44-btn--contextual" data-consent="accept-streaming-cookie">
+		                <span class="ds44-btnInnerText"><%= glp("jcmsplugin.socle.acceptercookies") %><i class="icon icon-long-arrow-right" aria-hidden="true"></i>
+		                </span>
+		            </button>
+		        </div>
+		    </div>
+	    </div>
     </div>
 </div>
 
@@ -66,5 +78,7 @@ String videoId = VideoUtils.getYoutubeVideoId(obj.getUrlVideo()); // récupérer
             %>
             <p><a href="<%= fichierTranscript %>" target="_blank" title="<%= glp("jcmsplugin.socle.video.telecharger-transcript.title", obj.getFichierTranscript(userLang).getTitle(),fileSize,fileType) %>"><%= glp("jcmsplugin.socle.video.telecharger-transcript.label") %></a></p>
         </jalios:if>
-        
+        <!-- Désactivation temporaire des chapitres -> l'overlay est la proprité. Sera remis une fois le JS traité 
         <%@ include file="doVideoChapitres.jspf" %>  
+        
+        -->


### PR DESCRIPTION
Chapitrage désactivé car le code JS actuel cause soucis. On ne peut avoir que l'un ou l'autre pour le moment. L'overlay est prioritaire.