### PR TITLE
Montée version 1.3 -> 2.1 infolocale

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/ApiUtil.java
@@ -14,6 +14,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
@@ -44,7 +45,7 @@ public class ApiUtil {
         .setConnectionRequestTimeout(timeout * 1000)
         .setSocketTimeout(timeout * 1000).build();
     
-      CloseableHttpClient httpClient =  HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+      CloseableHttpClient httpClient =  HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).setDefaultRequestConfig(config).build();
       
       HttpPost post = new HttpPost(url);
       
@@ -91,7 +92,7 @@ public class ApiUtil {
         .setSocketTimeout(timeout * 1000).build();
        
     
-      CloseableHttpClient httpClient =  HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+      CloseableHttpClient httpClient =  HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).setDefaultRequestConfig(config).build();
 
       HttpGet get = new HttpGet(url);
       

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/RequestManager.java
@@ -53,14 +53,14 @@ public class RequestManager {
      * Envoie une requête pour s'authentifier à Infolocale et générer les tokens d'authentification
      */
     public static void initTokens() {
-        sendTokenRequest("https://api.infolocale.fr/auth/signin", initToken, true);
+        sendTokenRequest("https://api.infolocale.fr/v2/auth/signin", initToken, true);
     }
     
     /**
      * Regénère les tokens d'authentification. En cas de token invalide, procède à l'authentification
      */
     public static void regenerateTokens() {
-        sendTokenRequest("https://api.infolocale.fr/auth/refresh-token", refreshToken, false);
+        sendTokenRequest("https://api.infolocale.fr/v2/auth/refresh-token", refreshToken, false);
     }
     
     private static void sendTokenRequest(String url, String type, boolean stopOnFail) {

--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
@@ -796,31 +796,33 @@ public class InfolocaleUtil {
           return finalHoraire.toString();
       }
       
-      // Cas "date unique" -> on récupère la dateHoraire associée à la date courante
-      for (DateHoraires itDateHoraire : event.getDatesHoraires()) {
-          // boucle sur les dateHoraires
-          if (itDateHoraire.getDate().equals(currentDate.getDebut())) {
-              // date correspondante trouvée
-              for (int counterHoraire = 0; counterHoraire < itDateHoraire.getHorairesDebut().size(); counterHoraire++) {
-                  
-                  StringBuilder horaireToAdd = new StringBuilder();
-
-                  String horaire_1 = formatTimeToHhMm(itDateHoraire.getHorairesDebut().get(counterHoraire));
-                  String horaire_2 = formatTimeToHhMm(itDateHoraire.getHorairesFin().get(counterHoraire));
-                  
-                  if (horaire_1.equals(horaire_2) || Util.isEmpty(horaire_2)) {
-                      horaireToAdd.append(horaire_1);
-                    } else {
-                      horaireToAdd.append(shortened ? getShortenedHoraireDisplay(horaire_1, horaire_2) : getHoraireDisplay(horaire_1, horaire_2));
-                  }
-                 
-                  
-                  if (Util.notEmpty(horaireToAdd)) {
-                    finalHoraire.append(horaireToAdd.toString());
-                  }
-                  
-                  if (counterHoraire+1 < itDateHoraire.getHorairesDebut().size() && Util.notEmpty(horaireToAdd)) {
-                    finalHoraire.append(suffixeHoraire);
+      if (Util.notEmpty(event.getDatesHoraires())) {
+          // Cas "date unique" -> on récupère la dateHoraire associée à la date courante
+          for (DateHoraires itDateHoraire : event.getDatesHoraires()) {
+              // boucle sur les dateHoraires
+              if (itDateHoraire.getDate().equals(currentDate.getDebut())) {
+                  // date correspondante trouvée
+                  for (int counterHoraire = 0; counterHoraire < itDateHoraire.getHorairesDebut().size(); counterHoraire++) {
+                      
+                      StringBuilder horaireToAdd = new StringBuilder();
+    
+                      String horaire_1 = formatTimeToHhMm(itDateHoraire.getHorairesDebut().get(counterHoraire));
+                      String horaire_2 = formatTimeToHhMm(itDateHoraire.getHorairesFin().get(counterHoraire));
+                      
+                      if (horaire_1.equals(horaire_2) || Util.isEmpty(horaire_2)) {
+                          horaireToAdd.append(horaire_1);
+                        } else {
+                          horaireToAdd.append(shortened ? getShortenedHoraireDisplay(horaire_1, horaire_2) : getHoraireDisplay(horaire_1, horaire_2));
+                      }
+                     
+                      
+                      if (Util.notEmpty(horaireToAdd)) {
+                        finalHoraire.append(horaireToAdd.toString());
+                      }
+                      
+                      if (counterHoraire+1 < itDateHoraire.getHorairesDebut().size() && Util.notEmpty(horaireToAdd)) {
+                        finalHoraire.append(suffixeHoraire);
+                      }
                   }
               }
           }

--- a/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/SoclePlugin/properties/plugin.prop
@@ -537,8 +537,8 @@ jcmsplugin.socle.infolocale.password:
 jcmsplugin.socle.infolocale.limit: 20
 jcmsplugin.socle.infolocale.flux.default: f24ba875-a641-47aa-b1b5-01c23a1b6812
 jcmsplugin.socle.infolocale.defaultOrder: dateDebut asc
-jcmsplugin.socle.infolocale.flux.url: https://api.infolocale.fr/flux/
-jcmsplugin.socle.infolocale.extract.url: https://api.infolocale.fr/annonces/
+jcmsplugin.socle.infolocale.flux.url: https://api.infolocale.fr/v2/flux/
+jcmsplugin.socle.infolocale.extract.url: https://api.infolocale.fr/v2/annonces/
 jcmsplugin.socle.infolocale.organisme.dep.id.list: id1,id2,id3
 jcmsplugin.socle.infolocale.max.limit: 200
 jcmsplugin.socle.infolocale.photo.404.url: https://www.infolocale.fr/build/images/article/article_no_image.png


### PR DESCRIPTION
→ le comportement semble ne pas différer entre la 1.3 et la 2.1.
Des champs supplémentaires, mais inutilisés, ont été ajoutés aux contenus “événements”

Fonctionnellement la même chose présentement