### PR TITLE
Hotfix Timeline : suppression d'attribut

### DIFF
--- a/plugins/SoclePlugin/types/Timeline/doTimelineFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/Timeline/doTimelineFullDisplay.jsp
@@ -150,7 +150,7 @@ SimpleDateFormat sdf = new SimpleDateFormat("dd MMMM yyyy");
                                 <%
                                 Video itVideo = (Video) itElement;
                                 %>
-                                <ds:articleVideo video="<%= itVideo %>" hideTitle="<%= true %>" forcedHeight='<%= "327px" %>' noOffset="<%= true %>" noChapo="<%= true %>"/>
+                                <ds:articleVideo video="<%= itVideo %>" hideTitle="<%= true %>" forcedHeight='<%= "327px" %>' noOffset="<%= true %>"/>
                             </jalios:if>
                             <ds:figurePicture format="custom" width="510" height="327" pub="<%= itElement %>"/>
                             <jalios:if predicate="<%= Util.notEmpty(displayedText) %>">


### PR DESCRIPTION
L'attribut "noChapo" n'existe pas pour le tag "articleVideo" et génère une exception.
Il faudra voir s'il y a eu confusion et si l'attribut "noChapo" doit être remplacé par un autre attribut.