### PR TITLE
Fix : portlet carrousel

### DIFF
--- a/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
+++ b/plugins/SoclePlugin/types/PortletCarousel/doPortletCarouselBoxDisplay.jspf
@@ -51,18 +51,22 @@
 	<%@ include file="/types/PortletQueryForeach/doQuery.jspf"%>
 	<%@ include file="/types/PortletQueryForeach/doSort.jspf"%>
     
-    <jalios:if predicate='<%= Util.notEmpty(collection) %>'>
-	    <div class="ds44-container-large">
-		    <div class="mod--hidden ds44-list swipper-carousel-wrap ds44-posRel" data-nb-visible-slides="<%= collection.size() < 4 ? collection.size() : sliderAmounts %>">
-		        <div class="swiper-container">
-		            <ul class='swiper-wrapper ds44-list <%= cssSliderSize %> has-gutter-l ds44-carousel-swiper'>
-		                <%@ include file="/types/PortletQueryForeach/doForeachHeader.jspf"%>
-		                	<li class="swiper-slide">
-							    <jalios:media data="<%=itPub %>" template="<%= box.getSelectionDuTheme() %>"/>
-							</li>
-		                <%@ include file="/types/PortletQueryForeach/doForeachFooter.jspf"%>
-		            </ul>
-		        </div>
+    <jalios:buffer name="tuilesResult">
+        <%@ include file="/types/PortletQueryForeach/doForeachHeader.jspf"%>
+            <li class="swiper-slide">
+                <jalios:media data="<%=itPub %>" template="<%= box.getSelectionDuTheme() %>"/>
+            </li>
+        <%@ include file="/types/PortletQueryForeach/doForeachFooter.jspf"%>
+    </jalios:buffer>
+    
+    <jalios:if predicate='<%= Util.notEmpty(tuilesResult) %>'>
+        <div class="ds44-container-large">
+            <div class="mod--hidden ds44-list swipper-carousel-wrap ds44-posRel" data-nb-visible-slides="<%= collection.size() < 4 ? collection.size() : sliderAmounts %>">
+                <div class="swiper-container">
+                    <ul class='swiper-wrapper ds44-list <%= cssSliderSize %> has-gutter-l ds44-carousel-swiper'>
+                        <%= tuilesResult %>
+                    </ul>
+                </div>
 		    
 		        <button class="swiper-button-prev swiper-button-disabled" type="button">
 		            <i class="icon icon-left" aria-hidden="true"></i> <span


### PR DESCRIPTION
Mise en buffer des résultats avant affichage. En faisant l'affichage direct, les résultats etaient nuls, dans le contexte d'une portlet carrousel générée dynamiquement dans un gabrit full par ex.