### PR TITLE
Fix : bouton de deconnexion

### DIFF
--- a/plugins/SoclePlugin/jsp/include/logout.jsp
+++ b/plugins/SoclePlugin/jsp/include/logout.jsp
@@ -1,7 +1,7 @@
 <%@ include file="/jcore/topbar/items/doInitTopbarItem.jspf" %>
 
 <div class="topbar-application-menu topbar-item-wrapper">
-  <a title="<%= glp("ui.com.alt.logout") %>" href="front/logout.jsp" class="topbar-item">
+  <a title="<%= glp("ui.com.alt.logout") %>" href="front/logout.jsp" class="topbar-item ctxLogout modal confirm btn btn-logout">
     <jalios:icon src="glyph: icomoon-exit" alt="ui.com.alt.logout" />
   </a>
 </div>


### PR DESCRIPTION
Ajout d'une modale de confirmation pour le bouton de déconnexion rajouté en topbar. Sinon sans cet appel de modale la deconnexion ne fonctionne pas en 10.0.5