### PR TITLE
Fix iframe video

### DIFF
--- a/WEB-INF/tags/titleSimple.tag
+++ b/WEB-INF/tags/titleSimple.tag
@@ -167,7 +167,7 @@ if(Util.notEmpty(video)) {
                <div>
                   <div class="ds44-cookie-overlay-container">
                      <div class="ds44-video-container">
-                        <iframe title='<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.acceder", titreVideo)) %>' style="width: 100%; height: 480px; border: none;" src="<%= urlVideo %>" allowfullscreen></iframe>
+                        <iframe type="opt-in" data-name="streaming-video" data-src="<%= urlVideo %>" title='<%= HttpUtil.encodeForHTMLAttribute(JcmsUtil.glp(userLang, "jcmsplugin.socle.video.acceder", titreVideo)) %>' style="width: 100%; height: 480px; border: none;" allowfullscreen></iframe>
                      </div>
                      <div class="ds44-media-overlay" style="display: none;">
 		               <div class="ds44-msg-media-desactive">

--- a/plugins/SoclePlugin/jsp/portal/aidants/footerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/aidants/footerSection.jsp
@@ -6,8 +6,8 @@
     <div class="grid-12-small-1 ds44-hasGutter-xxl">
         <div class="col-2-small-1">
             <div class="ds44-logo ds44-mb3 ds44-mobile-reduced-mt ds44-mobile-reduced-pt">
-                <img src="//design.loire-atlantique.fr/assets/images/logos/logo-udaf.svg" alt="UDAF Loire-Atlantique : Le site des aidants">
-                <img src='<%= channel.getProperty("jcmsplugin.socle.site.src.logofooter") %>' alt="Loire Atlantique" class="mbm">
+                <img src="//design.loire-atlantique.fr/assets/images/logos/logo-udaf.svg" alt="UDAF Loire-Atlantique : Le site des aidants" class="mbm">
+                <img src='<%= channel.getProperty("jcmsplugin.socle.site.src.logofooter") %>' alt="Loire Atlantique">
             </div>
         </div>
         <div class="col-5-small-1 ds44-mb3">

--- a/plugins/SoclePlugin/jsp/portal/aidants/footerSection.jsp
+++ b/plugins/SoclePlugin/jsp/portal/aidants/footerSection.jsp
@@ -6,8 +6,8 @@
     <div class="grid-12-small-1 ds44-hasGutter-xxl">
         <div class="col-2-small-1">
             <div class="ds44-logo ds44-mb3 ds44-mobile-reduced-mt ds44-mobile-reduced-pt">
+                <img src="//design.loire-atlantique.fr/assets/images/logos/logo-udaf.svg" alt="UDAF Loire-Atlantique : Le site des aidants">
                 <img src='<%= channel.getProperty("jcmsplugin.socle.site.src.logofooter") %>' alt="Loire Atlantique" class="mbm">
-                <img src="//dev-design.loire-atlantique.fr/assets/images/logos/logo-udaf.svg" alt="UDAF Loire-Atlantique : Le site des aidants">
             </div>
         </div>
         <div class="col-5-small-1 ds44-mb3">

--- a/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
+++ b/plugins/SoclePlugin/types/Video/doVideoEmbedDisplay.jsp
@@ -68,7 +68,7 @@ String videoId = VideoUtils.getYoutubeVideoId(obj.getUrlVideo()); // récupérer
     <div class="ds44-cookie-overlay-container">
 	    <div class="ds44-video-container">
 			
-			<iframe title='<%= HttpUtil.encodeForHTML(glp("jcmsplugin.socle.video.acceder", titleVideo)) %>' id="<%=uniqueIDiframe%>" class="ds44-hiddenPrint ds44-video-item" style="width: 100%; height: <%= heightIframe %>; border: none;" src="<%=urlVideo%>" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+			<iframe type="opt-in" data-name="streaming-video" data-src="<%=urlVideo%>" title='<%= HttpUtil.encodeForHTML(glp("jcmsplugin.socle.video.acceder", titleVideo)) %>' id="<%=uniqueIDiframe%>" class="ds44-hiddenPrint ds44-video-item" style="width: 100%; height: <%= heightIframe %>; border: none;" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
 			<div class="ds44-media-overlay" style="display: none;">
 		        <div class="ds44-msg-media-desactive">
 		            <p><%= glp("jcmsplugin.socle.videodesactivee") %></p>


### PR DESCRIPTION
Corrige le problème de chargement de l'iframe Youtube (et le dépôt de cookie) malgré la non acceptation des cookies de streaming.
Ajout les paramètres de Orejime : type, data-name et data-src à la place de src.