### PR TITLE
Fix : recherche par commune

### DIFF
--- a/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
+++ b/plugins/SoclePlugin/jsp/facettes/displayResult.jsp
@@ -45,6 +45,7 @@ int maxResult = box.getMaxResults();
 if(Util.notEmpty(collection) && "true".equalsIgnoreCase(request.getParameter("sectorisation"))) {
   request.setAttribute("communeHorsSectorisation", true);
   QueryHandler qhCommune = new QueryHandler(box.getQueries()[0]);
+  qhCommune.setLoggedMember(loggedMember);
   Set resultCommuneSet = qhCommune.getResultSet();
   request.removeAttribute("communeHorsSectorisation");
   


### PR DESCRIPTION
Les contenus en accès restreint ne sont pas affichés, même si on est connecté. En effet, l'utilisateur courant n'est pas transmis au Query handler.
NOTE : correctif à appliquer sans doutes dans d'autres fichiers car le loggedMember ne semble pas souvent passé aux différents QueryHandler.