### PR TITLE
Evol : InfolocaleAlarmListener

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/channellistener/SocleChannelListener.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/channellistener/SocleChannelListener.java
@@ -102,7 +102,10 @@ public class SocleChannelListener extends ChannelListener{
 	 * Initialise l'alarmlistener des tokens Infolocale
 	 */
 	private void initInfolocaleTokenAlarmListener() {
-		String schedule = Channel.getChannel().getProperty("jcmsplugin.socle.infolocale.schedule");
+    if (!Channel.getChannel().getBooleanProperty("jcmsplugin.socle.infolocale.enabled", true)) {
+      return;
+    }
+	  String schedule = Channel.getChannel().getProperty("jcmsplugin.socle.infolocale.schedule");
 		InfolocaleTokenAlarmListener alarmListener = new InfolocaleTokenAlarmListener();
 		AlarmEntry alarmEntry;
 		try {


### PR DESCRIPTION
Active le listener par défaut mais donne la possibilité de le désactiver pour les sites ne contenant pas d'agenda. Evite les erreurs lorsque le site n'est pas autorisé à appeler l'API.