### PR TITLE
Quickfix erreur display horaires fulldisplay infolocale

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
+++ b/WEB-INF/classes/fr/cg44/plugin/socle/infolocale/util/InfolocaleUtil.java
@@ -746,9 +746,19 @@ public class InfolocaleUtil {
      * @return
      */
     public static String getHoraireDisplay(EvenementInfolocale event, boolean shortened) {
+      return getHoraireDisplay(event, shortened, 0);
+    }
+    
+    /**
+     * Renvoie un horaire de date infolocale dans un format propre
+     * @param event
+     * @param hortened
+     * @return
+     */
+    public static String getHoraireDisplay(EvenementInfolocale event, boolean shortened, int dateIndex) {
       if (Util.isEmpty(event) || Util.isEmpty(event.getDates()) || (Util.isEmpty(event.getDatesHoraires()) && Util.isEmpty(event.getHoraires()))) return "";
       
-      DateInfolocale currentDate = event.getDates()[0];
+      DateInfolocale currentDate = event.getDates()[dateIndex];
       
       StringBuilder finalHoraire = new StringBuilder();
       

--- a/plugins/SoclePlugin/types/EvenementInfolocale/doEvenementInfolocaleFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/EvenementInfolocale/doEvenementInfolocaleFullDisplay.jsp
@@ -49,7 +49,7 @@ boolean texteCourtEmpty = Util.isEmpty(obj.getTexteCourt()) || "null".equals(obj
 boolean hasTexteLong = Util.notEmpty(obj.getTexteLong()) && !"null".equals(obj.getTexteLong());
 boolean descEmpty = Util.isEmpty(obj.getDescription()) || "null".equals(obj.getDescription());
 
-String displayHoraires = InfolocaleUtil.getHoraireDisplay(obj, true);
+String displayHoraires = InfolocaleUtil.getHoraireDisplay(obj, true, dateIndex);
 boolean allowHorairesDisplay = Util.notEmpty(displayHoraires) && !displayHoraires.equals(channel.getProperty("jcmsplugin.socle.infolocale.technique.multipleHorairesEvent")) ;
 boolean showPlagesHoraires = Util.notEmpty(displayHoraires) && displayHoraires.equals(channel.getProperty("jcmsplugin.socle.infolocale.technique.multipleHorairesEvent")) ;
 


### PR DESCRIPTION
Retournait toujours les horaires de la première date sur un fulldisplay, même si on affichait les informations de la date 2 par ex.