### PR TITLE
RS-2120 - cacher CS adresse physique si à écrire existe fiche lieu

### DIFF
--- a/plugins/SoclePlugin/types/FicheLieu/doFicheLieuFullDisplay.jsp
+++ b/plugins/SoclePlugin/types/FicheLieu/doFicheLieuFullDisplay.jsp
@@ -46,7 +46,7 @@
 
                     String adresseEcrire = SocleUtils.formatAdresseEcrire(obj);
                     
-                    if (adresse.equals(adresseEcrire)) adresse = SocleUtils.formatAdressePhysique(obj, true);
+                    if (Util.notEmpty(adresseEcrire) || adresse.equals(adresseEcrire)) adresse = SocleUtils.formatAdressePhysique(obj, true);
                 %>
                 <jalios:if
                     predicate='<%=Util.notEmpty(obj.getComplementTypeDacces()) || Util.notEmpty(adresse)


### PR DESCRIPTION
Juste un changement de condition sur un full display pour correspondre à la demande du ticket
Le CS indiqué dans le type est utilisé à la fois dans une adresse et dans l'autre. J'ai conservé l'ancienne condition pour raison d'historique, bien que celle-ci ne soit logiquement pas nécessaire...